### PR TITLE
Remove CreateEncodedStream variant API

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -60,9 +60,7 @@ decoder part of a codec.
 The Streams definition doesn't use WebIDL much, but the WebRTC spec does.
 This specification shows the IDL extensions for WebRTC.
 
-It uses an extension to RTCConfiguration in order to notify the
-{{RTCPeerConnection}} that insertable streams will be used, and uses
-an additional API on {{RTCRtpSender}} and {{RTCRtpReceiver}} to
+It uses an additional API on {{RTCRtpSender}} and {{RTCRtpReceiver}} to
 insert the processing into the pipeline.
 
 <pre class="idl">
@@ -72,21 +70,14 @@ dictionary RTCInsertableStreams {
     WritableStream writable;
 };
 
-// New fields in RTCConfiguration
-partial dictionary RTCConfiguration {
-    boolean encodedInsertableStreams = false;
-};
-
 typedef (SFrameTransform or RTCRtpScriptTransform) RTCRtpTransform;
 
 // New methods for RTCRtpSender and RTCRtpReceiver
 partial interface RTCRtpSender {
-    RTCInsertableStreams createEncodedStreams();
     attribute RTCRtpTransform? transform;
 };
 
 partial interface RTCRtpReceiver {
-    RTCInsertableStreams createEncodedStreams();
     attribute RTCRtpTransform? transform;
 };
 </pre>
@@ -101,7 +92,6 @@ argument, ensure that the codec is disabled and produces no output.
 ### Stream creation ### {#stream-creation}
 
 At construction of each {{RTCRtpSender}} or {{RTCRtpReceiver}}, run the following steps:
-1. Initialize [=this=].`[[Streams]]` to null.
 2. Initialize [=this=].`[[transform]]` to null.
 3. Initialize [=this=].`[[readable]]` to a new {{ReadableStream}}.
 4. <a dfn for="ReadableStream">Set up</a> [=this=].`[[readable]]`. [=this=].`[[readable]]` is provided frames using the [=readEncodedData=] algorithm given |this| as parameter.
@@ -111,23 +101,11 @@ At construction of each {{RTCRtpSender}} or {{RTCRtpReceiver}}, run the followin
 8. Set [=this=].`[[writable]]`.`[[owner]]` to |this|.
 9. Initialize [=this=].`[[pipeToController]]` to null.
 10. Initialize [=this=].`[[lastReceivedFrameTimestamp]]` to zero.
-11. If the {{RTCPeerConnection}}'s configuration does not have {{RTCConfiguration/encodedInsertableStreams}} set to "true", [=queue a task=] to run the following steps:
+11. [=Queue a task=] to run the following steps:
     1. If [=this=].`[[pipeToController]]` is not null, abort these steps.
     2. Set [=this=].`[[pipeToController]]` to a new {{AbortController}}.
     <!-- FIXME: Use pipeTo algorithm when available. -->
     3. Call <a href="https://streams.spec.whatwg.org/#readable-stream-pipe-to">pipeTo</a> with [=this=].`[[readable]]`, [=this=].`[[writable]]`, preventClose equal to true, preventAbort equal to true, preventCancel equal to true and [=this=].`[[pipeToController]]`.signal.
-
-The <dfn method for="RTCRtpSender">createEncodedStreams()</dfn> method steps are:
-
-1. If the {{RTCPeerConnection}}'s configuration does not have {{RTCConfiguration/encodedInsertableStreams}} set to "true", throw an "{{InvalidAccessError}}" {{DOMException}} and abort these steps.
-2. If the data source does not permit access, throw an "{{InvalidAccessError}}" {{DOMException}} and abort these steps.
-3. If [=this=].`[[Streams]]` is not null, throw an "{{InvalidAccessError}}" {{DOMException}}.
-4. If [=this=].`[[pipeToController]]` is not null, throw an "{{InvalidAccessError}}" {{DOMException}}.
-5. Set [=this=].`[[Streams]]` to an {{RTCInsertableStreams}} object.
-6. Set [=this=].`[[Streams]]`.{{RTCInsertableStreams/readable}} to [=this=].`[[readable]]`.
-7. Set [=this=].`[[Streams]]`.{{RTCInsertableStreams/writable}} to [=this=].`[[writable]]`.
-8. Enable the encoded data source.
-10. Return [=this=].`[[Streams]]`.
 
 ### Stream processing ### {#stream-processing}
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-insertable-streams/pull/64.html" title="Last updated on Apr 15, 2021, 8:07 AM UTC (523b1f1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/64/1bc1946...youennf:523b1f1.html" title="Last updated on Apr 15, 2021, 8:07 AM UTC (523b1f1)">Diff</a>