### PR TITLE
Add support for long keyID values

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -230,7 +230,7 @@ The SFrame transform algorithm, given |sframe| as a SFrameTransform object and |
 ## Methods
 The <dfn method for="SFrameTransform">setEncryptionKey(|key|, |keyID|)</dfn> method steps are:
 1. Let |promise| be [=a new promise=].
-2. If |keyID| is a <a href="https://heycam.github.io/webidl/#idl-bigint">BigInt</a> which cannot be represented as a integer between 0 and 2<sup>64</sup>-1 inclusive, [=reject=] |promise| with a {{RangeError}} exception.
+2. If |keyID| is a <a href="https://heycam.github.io/webidl/#idl-bigint">bigint</a> which cannot be represented as a integer between 0 and 2<sup>64</sup>-1 inclusive, [=reject=] |promise| with a {{RangeError}} exception.
 3. Otherwise, [=in parallel=], run the following steps:
     1. Set |key| with its optional |keyID| as key material to use for the SFrame transform algorithm, as defined by the <a href="https://datatracker.ietf.org/doc/draft-omara-sframe/">SFrame specification</a>.
     2. If setting the key material fails, [=reject=] |promise| with an {{InvalidModificationError}} exception and abort these steps.

--- a/index.bs
+++ b/index.bs
@@ -191,10 +191,13 @@ dictionary SFrameTransformOptions {
     SFrameTransformRole role = "encrypt";
 };
 
+typedef [EnforceRange] unsigned long long SmallCryptoKeyID;
+typedef (SmallCryptoKeyID or BigInt) CryptoKeyID;
+
 [Exposed=(Window,DedicatedWorker)]
 interface SFrameTransform {
     constructor(optional SFrameTransformOptions options = {});
-    Promise<undefined> setEncryptionKey(CryptoKey key, optional unsigned long long keyID);
+    Promise<undefined> setEncryptionKey(CryptoKey key, optional CryptoKeyID keyID);
 };
 SFrameTransform includes GenericTransformStream;
 </xmp>
@@ -227,11 +230,12 @@ The SFrame transform algorithm, given |sframe| as a SFrameTransform object and |
 ## Methods
 The <dfn method for="SFrameTransform">setEncryptionKey(|key|, |keyID|)</dfn> method steps are:
 1. Let |promise| be [=a new promise=].
-2.  [=In parallel=], run the following steps:
+2. If |keyID| is a <a href="https://heycam.github.io/webidl/#idl-bigint">bigint</a> which cannot be represented as a value in the range [0, 2<sup>64</sup>-1], [=reject=] |promise| with a {{RangeError}} exception.
+3. Otherwise, [=in parallel=], run the following steps:
     1. Set |key| with its optional |keyID| as key material to use for the SFrame transform algorithm, as defined by the <a href="https://datatracker.ietf.org/doc/draft-omara-sframe/">SFrame specification</a>.
-    2. If setting the key material fails, [=Reject=] |promise| with an {{InvalidModificationError}} error and abort these steps.
+    2. If setting the key material fails, [=reject=] |promise| with an {{InvalidModificationError}} exception and abort these steps.
     3. [=Resolve=] |promise| with undefined.
-3. Return |promise|.
+4. Return |promise|.
 
 
 # RTCRtpScriptTransform # {#scriptTransform}

--- a/index.bs
+++ b/index.bs
@@ -28,6 +28,9 @@ spec:webidl; type:dfn; text:resolve
 <pre class=link-defaults>
 spec:streams; type:interface; text:ReadableStream
 </pre>
+<pre class=anchors>
+url: https://heycam.github.io/webidl/#idl-bigint; type: interface; text: BigInt
+</pre>
 
 # Introduction # {#introduction}
 
@@ -191,9 +194,6 @@ dictionary SFrameTransformOptions {
     SFrameTransformRole role = "encrypt";
 };
 
-// FIXME: Remove BigInt declaration once WebIDL parser is aware of it.
-interface BigInt {
-};
 typedef [EnforceRange] unsigned long long SmallCryptoKeyID;
 typedef (SmallCryptoKeyID or BigInt) CryptoKeyID;
 
@@ -233,7 +233,7 @@ The SFrame transform algorithm, given |sframe| as a SFrameTransform object and |
 ## Methods
 The <dfn method for="SFrameTransform">setEncryptionKey(|key|, |keyID|)</dfn> method steps are:
 1. Let |promise| be [=a new promise=].
-2. If |keyID| is a <a href="https://heycam.github.io/webidl/#idl-bigint">BigInt</a> which cannot be represented as a integer between 0 and 2<sup>64</sup>-1 inclusive, [=reject=] |promise| with a {{RangeError}} exception.
+2. If |keyID| is a {{BigInt}} which cannot be represented as a integer between 0 and 2<sup>64</sup>-1 inclusive, [=reject=] |promise| with a {{RangeError}} exception.
 3. Otherwise, [=in parallel=], run the following steps:
     1. Set |key| with its optional |keyID| as key material to use for the SFrame transform algorithm, as defined by the <a href="https://datatracker.ietf.org/doc/draft-omara-sframe/">SFrame specification</a>.
     2. If setting the key material fails, [=reject=] |promise| with an {{InvalidModificationError}} exception and abort these steps.

--- a/index.bs
+++ b/index.bs
@@ -230,7 +230,7 @@ The SFrame transform algorithm, given |sframe| as a SFrameTransform object and |
 ## Methods
 The <dfn method for="SFrameTransform">setEncryptionKey(|key|, |keyID|)</dfn> method steps are:
 1. Let |promise| be [=a new promise=].
-2. If |keyID| is a <a href="https://heycam.github.io/webidl/#idl-bigint">bigint</a> which cannot be represented as a integer between 0 and 2<sup>64</sup>-1 inclusive, [=reject=] |promise| with a {{RangeError}} exception.
+2. If |keyID| is a <a href="https://heycam.github.io/webidl/#idl-bigint">BigInt</a> which cannot be represented as a integer between 0 and 2<sup>64</sup>-1 inclusive, [=reject=] |promise| with a {{RangeError}} exception.
 3. Otherwise, [=in parallel=], run the following steps:
     1. Set |key| with its optional |keyID| as key material to use for the SFrame transform algorithm, as defined by the <a href="https://datatracker.ietf.org/doc/draft-omara-sframe/">SFrame specification</a>.
     2. If setting the key material fails, [=reject=] |promise| with an {{InvalidModificationError}} exception and abort these steps.

--- a/index.bs
+++ b/index.bs
@@ -230,7 +230,7 @@ The SFrame transform algorithm, given |sframe| as a SFrameTransform object and |
 ## Methods
 The <dfn method for="SFrameTransform">setEncryptionKey(|key|, |keyID|)</dfn> method steps are:
 1. Let |promise| be [=a new promise=].
-2. If |keyID| is a <a href="https://heycam.github.io/webidl/#idl-bigint">bigint</a> which cannot be represented as a value in the range [0, 2<sup>64</sup>-1], [=reject=] |promise| with a {{RangeError}} exception.
+2. If |keyID| is a <a href="https://heycam.github.io/webidl/#idl-bigint">BigInt</a> which cannot be represented as a integer between 0 and 2<sup>64</sup>-1 inclusive, [=reject=] |promise| with a {{RangeError}} exception.
 3. Otherwise, [=in parallel=], run the following steps:
     1. Set |key| with its optional |keyID| as key material to use for the SFrame transform algorithm, as defined by the <a href="https://datatracker.ietf.org/doc/draft-omara-sframe/">SFrame specification</a>.
     2. If setting the key material fails, [=reject=] |promise| with an {{InvalidModificationError}} exception and abort these steps.

--- a/index.bs
+++ b/index.bs
@@ -191,6 +191,9 @@ dictionary SFrameTransformOptions {
     SFrameTransformRole role = "encrypt";
 };
 
+// FIXME: Remove BigInt declaration once WebIDL parser is aware of it.
+interface BigInt {
+};
 typedef [EnforceRange] unsigned long long SmallCryptoKeyID;
 typedef (SmallCryptoKeyID or BigInt) CryptoKeyID;
 


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-insertable-streams/issues/69


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-insertable-streams/pull/77.html" title="Last updated on Mar 19, 2021, 10:06 AM UTC (150a68d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/77/b5fae15...youennf:150a68d.html" title="Last updated on Mar 19, 2021, 10:06 AM UTC (150a68d)">Diff</a>