### PR TITLE
Fix case of Web IDL bigint type

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -28,9 +28,6 @@ spec:webidl; type:dfn; text:resolve
 <pre class=link-defaults>
 spec:streams; type:interface; text:ReadableStream
 </pre>
-<pre class=anchors>
-url: https://heycam.github.io/webidl/#idl-bigint; type: interface; text: BigInt
-</pre>
 
 # Introduction # {#introduction}
 
@@ -195,7 +192,7 @@ dictionary SFrameTransformOptions {
 };
 
 typedef [EnforceRange] unsigned long long SmallCryptoKeyID;
-typedef (SmallCryptoKeyID or BigInt) CryptoKeyID;
+typedef (SmallCryptoKeyID or bigint) CryptoKeyID;
 
 [Exposed=(Window,DedicatedWorker)]
 interface SFrameTransform {
@@ -233,7 +230,7 @@ The SFrame transform algorithm, given |sframe| as a SFrameTransform object and |
 ## Methods
 The <dfn method for="SFrameTransform">setEncryptionKey(|key|, |keyID|)</dfn> method steps are:
 1. Let |promise| be [=a new promise=].
-2. If |keyID| is a {{BigInt}} which cannot be represented as a integer between 0 and 2<sup>64</sup>-1 inclusive, [=reject=] |promise| with a {{RangeError}} exception.
+2. If |keyID| is a {{bigint}} which cannot be represented as a integer between 0 and 2<sup>64</sup>-1 inclusive, [=reject=] |promise| with a {{RangeError}} exception.
 3. Otherwise, [=in parallel=], run the following steps:
     1. Set |key| with its optional |keyID| as key material to use for the SFrame transform algorithm, as defined by the <a href="https://datatracker.ietf.org/doc/draft-omara-sframe/">SFrame specification</a>.
     2. If setting the key material fails, [=reject=] |promise| with an {{InvalidModificationError}} exception and abort these steps.


### PR DESCRIPTION
Introduced in https://github.com/w3c/webrtc-encoded-transform/pull/77

Per https://heycam.github.io/webidl/#idl-bigint the type is spelled "bigint".

This isn't used in any other spec yet, but there are examples of this in tests:
https://github.com/w3c/webidl2.js/blob/9e8b5a0247f2cffccc6265c6577f98a0883d3a60/test/syntax/idl/bigint.webidl


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/webrtc-insertable-streams/pull/92.html" title="Last updated on Mar 23, 2021, 8:31 AM UTC (a0b407b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/92/566cd58...foolip:a0b407b.html" title="Last updated on Mar 23, 2021, 8:31 AM UTC (a0b407b)">Diff</a>