### PR TITLE
Add a new parameter to RTCRtpScriptTransform constructor to allow transferring objects in the options parameter

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -303,19 +303,18 @@ interface RTCRtpScriptTransformer {
 
 [Exposed=Window]
 interface RTCRtpScriptTransform {
-    constructor(Worker worker, optional any options);
-    // FIXME: add messaging methods.
+    constructor(Worker worker, optional any options, optional sequence&lt;object&gt; transfer);
 };
 </pre>
 
 ## Operations ## {#RTCRtpScriptTransform-operations}
 
-The <dfn constructor for="RTCRtpScriptTransform" lt="RTCRtpScriptTransform(worker, options)"><code>new RTCRtpScriptTransform(<var>worker</var>, <var>options</var>)</code></dfn> constructor steps are:
+The <dfn constructor for="RTCRtpScriptTransform" lt="RTCRtpScriptTransform(worker, options)"><code>new RTCRtpScriptTransform(|worker|, |options|, |transfer|)</code></dfn> constructor steps are:
 1. Set |t1| to an [=identity transform stream=].
 2. Set |t2| to an [=identity transform stream=].
 3. Set |this|.`[[writable]]` to |t1|.`[[writable]]`.
 4. Set |this|.`[[readable]]` to |t2|.`[[readable]]`.
-5. Let |serializedOptions| be the result of [$StructuredSerialize$](|options|).
+5. Let |serializedOptions| be the result of [$StructuredSerializeWithTransfer$](|options|, |transfer|).
 6. Let |serializedReadable| be the result of [$StructuredSerializeWithTransfer$](|t1|.`[[readable]]`, « |t1|.`[[readable]]` »).
 7. Let |serializedWritable| be the result of [$StructuredSerializeWithTransfer$](|t2|.`[[writable]]`, « |t2|.`[[writable]]` »).
 8. [=Queue a task=] on the DOM manipulation [=task source=] |worker|'s global scope to run the following steps:


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-encoded-transform/issues/94


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-insertable-streams/pull/96.html" title="Last updated on Apr 8, 2021, 1:35 PM UTC (b969031)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/96/733f771...youennf:b969031.html" title="Last updated on Apr 8, 2021, 1:35 PM UTC (b969031)">Diff</a>