### PR TITLE
Ensure receiver-side transform order is the same as sender-side transform order

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -100,8 +100,9 @@ At construction of each {{RTCRtpSender}} or {{RTCRtpReceiver}}, run the followin
 7. <a dfn for="WritableStream">Set up</a> [=this=].`[[writable]]` with its [=WritableStream/set up/writeAlgorithm=] set to [=writeEncodedData=] given |this| as parameter.
 8. Set [=this=].`[[writable]]`.`[[owner]]` to |this|.
 9. Initialize [=this=].`[[pipeToController]]` to null.
-10. Initialize [=this=].`[[lastReceivedFrameTimestamp]]` to zero.
-11. [=Queue a task=] to run the following steps:
+1. Initialize [=this=].`[[lastReceivedFrameCounter]]` to <code>0</code>.
+1. Initialize [=this=].`[[lastEnqueuedFrameCounter]]` to <code>0</code>.
+1. [=Queue a task=] to run the following steps:
     1. If [=this=].`[[pipeToController]]` is not null, abort these steps.
     2. Set [=this=].`[[pipeToController]]` to a new {{AbortController}}.
     <!-- FIXME: Use pipeTo algorithm when available. -->
@@ -111,14 +112,16 @@ At construction of each {{RTCRtpSender}} or {{RTCRtpReceiver}}, run the followin
 
 The <dfn>readEncodedData</dfn> algorithm is given a |rtcObject| as parameter. It is defined by running the following steps:
 1. Wait for a frame to be produced by |rtcObject|'s encoder if it is a {{RTCRtpSender}} or |rtcObject|'s packetizer if it is a {{RTCRtpReceiver}}.
-2. Let |frame| be the newly produced frame.
-3. Set |frame|.`[[owner]]` to |rtcObject|.
-4. [=ReadableStream/Enqueue=] |frame| in |rtcObject|.`[[readable]]`.
+1. Increment |rtcObject|.`[[lastEnqueuedFrameCounter]]` by <code>1</code>.
+1. Let |frame| be the newly produced frame.
+1. Set |frame|.`[[owner]]` to |rtcObject|.
+1. Set |frame|.`[[counter]]` to |rtcObject|.`[[lastEnqueuedFrameCounter]]`.
+1. [=ReadableStream/Enqueue=] |frame| in |rtcObject|.`[[readable]]`.
 
 The <dfn>writeEncodedData</dfn> algorithm is given a |rtcObject| as parameter and a |frame| as input. It is defined by running the following steps:
 1. If |frame|.`[[owner]]` is not equal to |rtcObject|, abort these steps and return [=a promise resolved with=] undefined. A processor cannot create frames, or move frames between streams.
-2. If the |frame|'s {{RTCEncodedVideoFrame/timestamp}} is equal to or larger than |rtcObject|.`[[lastReceivedFrameTimestamp]]`, abort these steps and return [=a promise resolved with=] undefined. A processor cannot reorder frames, although it may delay them or drop them.
-3. Set |rtcObject|.`[[lastReceivedFrameTimestamp]]` to the |frame|'s {{RTCEncodedVideoFrame/timestamp}}.
+1. If |frame|.`[[counter]]` is equal or smaller than |rtcObject|.`[[lastReceivedFrameCounter]]`, abort these steps and return [=a promise resolved with=] undefined. A processor cannot reorder frames, although it may delay them or drop them.
+1. Set |rtcObject|.`[[lastReceivedFrameCounter]]` to |frame|`[[counter]]`.
 4. Enqueue the frame for processing as if it came directly from the encoded data source, by running one of the following steps:
     * If |rtcObject| is a {{RTCRtpSender}}, enqueue it to |rtcObject|'s packetizer, to be processed [=in parallel=].
     * If |rtcObject| is a {{RTCRtpReceiver}}, enqueue it to |rtcObject|'s decoder, to be processed [=in parallel=].

--- a/index.bs
+++ b/index.bs
@@ -124,6 +124,13 @@ The <dfn>writeEncodedData</dfn> algorithm is given a |rtcObject| as parameter an
     * If |rtcObject| is a {{RTCRtpReceiver}}, enqueue it to |rtcObject|'s decoder, to be processed [=in parallel=].
 5. Return [=a promise resolved with=] undefined.
 
+On sender side, as part of [=readEncodedData=], frames produced by |rtcObject|'s encoder MUST be enqueued in |rtcObject|.`[[readable]]` in the encoder's output order.
+As [=writeEncodedData=] ensures that the transform cannot reorder frames, the encoder's output order is also the order followed by packetizers to generate RTP packets and assign RTP packet sequence numbers.
+
+On receiver side, as part of [=readEncodedData=], frames produced by |rtcObject|'s packetizer MUST be enqueued in |rtcObject|.`[[readable]]` in the same encoder's output order.
+To ensure the order is respected, the packetizer will typically use RTP packet sequence numbers to reorder RTP packets as needed before enqueuing frames in |rtcObject|.`[[readable]]`.
+As [=writeEncodedData=] ensures that the transform cannot reorder frames, this will be the order expected by |rtcObject|'s decoder.
+
 ## Extension attribute ## {#attribute}
 
 A RTCRtpTransform has two private slots called `[[readable]]` and `[[writable]]`.

--- a/index.bs
+++ b/index.bs
@@ -131,7 +131,7 @@ On sender side, as part of [=readEncodedData=], frames produced by |rtcObject|'s
 As [=writeEncodedData=] ensures that the transform cannot reorder frames, the encoder's output order is also the order followed by packetizers to generate RTP packets and assign RTP packet sequence numbers.
 
 On receiver side, as part of [=readEncodedData=], frames produced by |rtcObject|'s packetizer MUST be enqueued in |rtcObject|.`[[readable]]` in the same encoder's output order.
-To ensure the order is respected, the packetizer will typically use RTP packet sequence numbers to reorder RTP packets as needed before enqueuing frames in |rtcObject|.`[[readable]]`.
+To ensure the order is respected, the depacketizer will typically use RTP packet sequence numbers to reorder RTP packets as needed before enqueuing frames in |rtcObject|.`[[readable]]`.
 As [=writeEncodedData=] ensures that the transform cannot reorder frames, this will be the order expected by |rtcObject|'s decoder.
 
 ## Extension attribute ## {#attribute}


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-encoded-transform/issues/109


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-insertable-streams/pull/110.html" title="Last updated on Jul 1, 2021, 2:17 PM UTC (7f10c04)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/110/f9d5d59...youennf:7f10c04.html" title="Last updated on Jul 1, 2021, 2:17 PM UTC (7f10c04)">Diff</a>