### PR TITLE
Rename SFrameTransformErrorEvent.type to SFrameTransformErrorEvent.errorType

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -192,13 +192,13 @@ enum SFrameTransformErrorEventType {
 interface SFrameTransformErrorEvent : Event {
     constructor(DOMString type, SFrameTransformErrorEventInit eventInitDict);
 
-    readonly attribute SFrameTransformErrorEventType type;
+    readonly attribute SFrameTransformErrorEventType errorType;
     readonly attribute CryptoKeyID? keyID;
     readonly attribute any frame;
 };
 
 dictionary SFrameTransformErrorEventInit : EventInit {
-    required SFrameTransformErrorEventType type;
+    required SFrameTransformErrorEventType errorType;
     required any frame;
     CryptoKeyID? keyID;
 };
@@ -227,13 +227,13 @@ The SFrame transform algorithm, given |sframe| as a SFrameTransform object and |
 1. Let |buffer| be the result of running the SFrame algorithm with |data| and |role| as parameters. This algorithm is defined by the <a href="https://datatracker.ietf.org/doc/draft-omara-sframe/">SFrame specification</a> and returns an {{ArrayBuffer}}.
 1. If the SFrame algorithm exits abruptly with an error, [=queue a task=] to run the following sub steps:
      1. If the processing fails on decryption side due to |data| not following the SFrame format, [=fire an event=] named {{SFrameTransform/onerror|error}} at |sframe|,
-        using the {{SFrameTransformErrorEvent}} interface with its {{SFrameTransformErrorEvent/type}} attribute set to {{SFrameTransformErrorEventType/syntax}}
+        using the {{SFrameTransformErrorEvent}} interface with its {{SFrameTransformErrorEvent/errorType}} attribute set to {{SFrameTransformErrorEventType/syntax}}
         and its {{SFrameTransformErrorEvent/frame}} attribute set to |frame|.
      1. If the processing fails on decryption side due to the key identifier parsed in |data| being unknown, [=fire an event=] named {{SFrameTransform/onerror|error}} at |sframe|,
-        using the {{SFrameTransformErrorEvent}} interface with its {{SFrameTransformErrorEvent/type}} attribute set to {{SFrameTransformErrorEventType/keyID}},
+        using the {{SFrameTransformErrorEvent}} interface with its {{SFrameTransformErrorEvent/errorType}} attribute set to {{SFrameTransformErrorEventType/keyID}},
         its {{SFrameTransformErrorEvent/frame}} attribute set to |frame| and its {{SFrameTransformErrorEvent/keyID}} attribute set to the keyID value parsed in the SFrame header.
      1. If the processing fails on decryption side due to validation of the authentication tag, [=fire an event=] named {{SFrameTransform/onerror|error}} at |sframe|,
-        using the {{SFrameTransformErrorEvent}} interface with its {{SFrameTransformErrorEvent/type}} attribute set to {{SFrameTransformErrorEventType/authentication}}
+        using the {{SFrameTransformErrorEvent}} interface with its {{SFrameTransformErrorEvent/errorType}} attribute set to {{SFrameTransformErrorEventType/authentication}}
         and its {{SFrameTransformErrorEvent/frame}} attribute set to |frame|.
      1. Abort these steps.
 1. If |frame| is a {{BufferSource}}, set |frame| to |buffer|.


### PR DESCRIPTION
We cannot use type as this would override Event.type itself.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 10, 2021, 10:09 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fyouennf%2Fwebrtc-insertable-streams%2F3eacf6a6d1352b45e8377db7efae7e71a2c48e6c%2Findex.bs&force=1&md-warning=not%20ready)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webrtc-encoded-transform%23113.)._
</details>
