### PR TITLE
fix type of timestamp attribute

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -289,7 +289,7 @@ dictionary RTCEncodedVideoFrameMetadata {
 [Exposed=(Window,DedicatedWorker)]
 interface RTCEncodedVideoFrame {
     readonly attribute RTCEncodedVideoFrameType type;
-    readonly attribute unsigned long long timestamp;
+    readonly attribute unsigned long timestamp;
     attribute ArrayBuffer data;
     RTCEncodedVideoFrameMetadata getMetadata();
 };
@@ -301,7 +301,7 @@ dictionary RTCEncodedAudioFrameMetadata {
 
 [Exposed=(Window,DedicatedWorker)]
 interface RTCEncodedAudioFrame {
-    readonly attribute unsigned long long timestamp;
+    readonly attribute unsigned long timestamp;
     attribute ArrayBuffer data;
     RTCEncodedAudioFrameMetadata getMetadata();
 };


### PR DESCRIPTION
this exposes the rtp timestamp in implementations so should be a unsigned long
to match the definition in RFC 3550.

@alvestrand PTAL