### PR TITLE
metadata: add payloadType

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -281,6 +281,7 @@ dictionary RTCEncodedVideoFrameMetadata {
     long spatialIndex;
     long temporalIndex;
     long synchronizationSource;
+    octet payloadType;
     sequence&lt;long&gt; contributingSources;
 };
 
@@ -296,6 +297,7 @@ interface RTCEncodedVideoFrame {
 
 dictionary RTCEncodedAudioFrameMetadata {
     long synchronizationSource;
+    octet payloadType;
     sequence&lt;long&gt; contributingSources;
 };
 


### PR DESCRIPTION
adds a payloadType attribute to the metadata. This is the RTP payload type
from the RTP header, with a range of [0,127].

This can be used to determine the codec of the encoded data and hence its
format.