### PR TITLE
Use aborted instead of aborted flag

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -156,7 +156,7 @@ The `transform` setter steps are:
 9. Set [=this=].`[[transform]]` to |transform|.
 
 The <dfn>chain transform algorithm</dfn> steps are defined as:
-1. If |newPipeToController|'s [=AbortSignal/aborted flag=] is true, abort these steps.
+1. If |newPipeToController| is [=AbortSignal/aborted=], abort these steps.
 2. [=ReadableStreamDefaultReader/Release=] |reader|.
 3. [=WritableStreamDefaultWriter/Release=] |writer|.
 4. Assert that |newPipeToController| is the same object as |rtcObject|.`[[pipeToController]]`.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-insertable-streams/pull/123.html" title="Last updated on Nov 19, 2021, 9:56 AM UTC (8ed6694)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/123/a377d84...youennf:8ed6694.html" title="Last updated on Nov 19, 2021, 9:56 AM UTC (8ed6694)">Diff</a>