### PR TITLE
Use unsigned long instead of long for positive values

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -275,7 +275,7 @@ enum RTCEncodedVideoFrameType {
 
 dictionary RTCEncodedVideoFrameMetadata {
     unsigned long long frameId;
-    sequence&lt;long long&gt; dependencies;
+    sequence&lt;unsigned long long&gt; dependencies;
     unsigned short width;
     unsigned short height;
     unsigned long spatialIndex;

--- a/index.bs
+++ b/index.bs
@@ -283,14 +283,14 @@ enum RTCEncodedVideoFrameType {
 };
 
 dictionary RTCEncodedVideoFrameMetadata {
-    long long frameId;
+    unsigned long long frameId;
     sequence&lt;long long&gt; dependencies;
     unsigned short width;
     unsigned short height;
-    long spatialIndex;
-    long temporalIndex;
-    long synchronizationSource;
-    sequence&lt;long&gt; contributingSources;
+    unsigned long spatialIndex;
+    unsigned long temporalIndex;
+    unsigned long synchronizationSource;
+    sequence&lt;unsigned long&gt; contributingSources;
 };
 
 // New interfaces to define encoded video and audio frames. Will eventually
@@ -304,8 +304,8 @@ interface RTCEncodedVideoFrame {
 };
 
 dictionary RTCEncodedAudioFrameMetadata {
-    long synchronizationSource;
-    sequence&lt;long&gt; contributingSources;
+    unsigned long synchronizationSource;
+    sequence&lt;unsigned long&gt; contributingSources;
 };
 
 [Exposed=(Window,DedicatedWorker)]


### PR DESCRIPTION
webkit implementation already uses unsigned long for some of these https://github.com/WebKit/WebKit/blob/5858e9511bb3d3306db3c4bc0973c521cdc97a03/Source/WebCore/Modules/mediastream/RTCEncodedVideoFrame.idl


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/pull/126.html" title="Last updated on Dec 7, 2021, 1:09 PM UTC (219dc98)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/126/4242a87...219dc98.html" title="Last updated on Dec 7, 2021, 1:09 PM UTC (219dc98)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/pull/126.html" title="Last updated on Oct 5, 2022, 7:07 AM UTC (f50263e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/126/f2797d7...f50263e.html" title="Last updated on Oct 5, 2022, 7:07 AM UTC (f50263e)">Diff</a>