### PR TITLE
Remove duplicate closing tag

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -26,7 +26,6 @@ spec:webidl; type:dfn; text:resolve
    }
 }
 </pre>
-</pre>
 <pre class=link-defaults>
 spec:streams; type:interface; text:ReadableStream
 </pre>


### PR DESCRIPTION
This PR just removes a duplicate `</pre>` tag which I think was introduced here:

https://github.com/w3c/webrtc-encoded-transform/pull/125/files#diff-5e793325cd2bfc452e268a4aa2f02b4024dd9584bd1db3c2595f61f1ecf7b985L27-R28


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chrisguttandin/webrtc-encoded-transform/pull/130.html" title="Last updated on Jan 30, 2022, 10:21 AM UTC (badb551)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/130/f80a936...chrisguttandin:badb551.html" title="Last updated on Jan 30, 2022, 10:21 AM UTC (badb551)">Diff</a>