### PR TITLE
Simplify event firing using DOM phrasing

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -365,10 +365,7 @@ The <dfn constructor for="RTCRtpScriptTransform" lt="RTCRtpScriptTransform(worke
     5. Set |transformer|.`[[options]]` to |transformerOptions|.
     6. Set |transformer|.`[[readable]]` to |readable|.
     7. Set |transformer|.`[[writable]]` to |writable|.
-    8. Let |event| be the result of [=creating an event=] with {{RTCTransformEvent}}.
-    9. Set |event|.type attribute to "rtctransform".
-    10. Set |event|.transformer to |transformer|.
-    11. Dispatch |event| on |worker|’s global scope.
+    8. [=Fire an event=] named <dfn event>rtctransform</dfn> using {{RTCTransformEvent}} with {{RTCTransformEvent/transformer}} set to |transformer| on |worker|’s global scope.
 
 // FIXME: Describe error handling (worker closing flag true at RTCRtpScriptTransform creation time. And worker being terminated while transform is processing data).
 

--- a/index.bs
+++ b/index.bs
@@ -365,7 +365,7 @@ The <dfn constructor for="RTCRtpScriptTransform" lt="RTCRtpScriptTransform(worke
     5. Set |transformer|.`[[options]]` to |transformerOptions|.
     6. Set |transformer|.`[[readable]]` to |readable|.
     7. Set |transformer|.`[[writable]]` to |writable|.
-    8. [=Fire an event=] named <dfn event>rtctransform</dfn> using {{RTCTransformEvent}} with {{RTCTransformEvent/transformer}} set to |transformer| on |worker|’s global scope.
+    8. [=Fire an event=] named <dfn event for="DedicatedWorkerGlobalScope">rtctransform</dfn> using {{RTCTransformEvent}} with {{RTCTransformEvent/transformer}} set to |transformer| on |worker|’s global scope.
 
 // FIXME: Describe error handling (worker closing flag true at RTCRtpScriptTransform creation time. And worker being terminated while transform is processing data).
 


### PR DESCRIPTION
see https://dom.spec.whatwg.org/#firing-events-example

this also helps with automated extraction of data from specs


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/pull/136.html" title="Last updated on Jun 8, 2022, 1:02 PM UTC (71924b2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/136/d5ef0b0...71924b2.html" title="Last updated on Jun 8, 2022, 1:02 PM UTC (71924b2)">Diff</a>