### PR TITLE
Add rtp timestamp and capture time to RTCEncodedVideoFrameMetadata

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -287,6 +287,8 @@ enum RTCEncodedVideoFrameType {
 
 dictionary RTCEncodedVideoFrameMetadata {
     long long frameId;
+    unsigned long rtpTimestamp; // RTP timestamp.
+    DOMHighResTimeStamp captureTime;
     sequence&lt;long long&gt; dependencies;
     unsigned short width;
     unsigned short height;


### PR DESCRIPTION
Add both RTP timestamp and captureTime to RTCEncodedVideoFrameMetadata. On the send side, the capture time should equal the timestamp of the corresponding unencoded VideoFrame. On the receive side, it is best effort.