### PR TITLE
add mimeType to metadata

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -341,6 +341,7 @@ dictionary RTCEncodedVideoFrameMetadata {
     sequence&lt;unsigned long&gt; contributingSources;
     long long timestamp;    // microseconds
     unsigned long rtpTimestamp;
+    DOMString mimeType;
 };
 </pre>
 
@@ -381,7 +382,7 @@ dictionary RTCEncodedVideoFrameMetadata {
     <dd>
         <p>
             The media presentation timestamp (PTS) in microseconds of raw frame, matching the
-      {{VideoFrame/timestamp}} for raw frames which correspond to this frame.
+            {{VideoFrame/timestamp}} for raw frames which correspond to this frame.
         </p>
     </dd>
     <dt>
@@ -392,6 +393,15 @@ dictionary RTCEncodedVideoFrameMetadata {
         <p>
             The RTP timestamp identifier is an unsigned integer value per [[RFC3550]]
             that reflects the sampling instant of the first octet in the RTP data packet.
+        </p>
+    </dd>
+    <dt>
+        <dfn dict-member>mimeType</dfn> <span class="idlMemberType">DOMString</span>
+    </dt>
+    <dd>
+        <p>
+            The codec MIME media type/subtype defined in the IANA media types registry
+            [[!IANA-MEDIA-TYPES]], e.g. video/VP8.
         </p>
     </dd>
 </dl>
@@ -473,6 +483,7 @@ dictionary RTCEncodedAudioFrameMetadata {
     sequence&lt;unsigned long&gt; contributingSources;
     short sequenceNumber;
     unsigned long rtpTimestamp;
+    DOMString mimeType;
 };
 </pre>
 ### Members ### {#RTCEncodedAudioFrameMetadata-members}
@@ -523,6 +534,15 @@ dictionary RTCEncodedAudioFrameMetadata {
         <p>
             The RTP timestamp identifier is an unsigned integer value per [[RFC3550]]
             that reflects the sampling instant of the first octet in the RTP data packet.
+        </p>
+    </dd>
+    <dt>
+        <dfn dict-member>mimeType</dfn> <span class="idlMemberType">DOMString</span>
+    </dt>
+    <dd>
+        <p>
+            The codec MIME media type/subtype defined in the IANA media types registry
+            [[!IANA-MEDIA-TYPES]], e.g. audio/opus.
         </p>
     </dd>
 </dl>


### PR DESCRIPTION
since they mapping from payload type to the codec mime type
is nontrivial in environments like workers.

Defined similar to webrtc-stats:
  https://w3c.github.io/webrtc-stats/#dom-rtccodecstats-mimetype

Fixes #158


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-media-streams/pull/140.html" title="Last updated on Oct 10, 2023, 5:37 PM UTC (52909d9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/140/7721c15...fippo:52909d9.html" title="Last updated on Oct 10, 2023, 5:37 PM UTC (52909d9)">Diff</a>