### PR TITLE
Make RTCRtpSender.generateKeyFrame take a single optional rid parameter.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -452,16 +452,16 @@ An additional API on {{RTCRtpSender}} is added to complement the generation of k
 
 <pre class="idl">
 partial interface RTCRtpSender {
-    Promise&lt;undefined&gt; generateKeyFrame(optional sequence &lt;DOMString&gt; rids);
+    Promise&lt;undefined&gt; generateKeyFrame(optional DOMString rid);
 };
 </pre>
 
 ## Extension operation ## {#sender-operation}
 
-The <dfn method for="RTCRtpSender">generateKeyFrame(|rids|)</dfn> method steps are:
+The <dfn method for="RTCRtpSender">generateKeyFrame(|rid|)</dfn> method steps are:
 
 1. Let |promise| be a new promise.
-1. [=In parallel=], run the [=generate key frame algorithm=] with |promise|, |this|'s encoder and |rids|.
+1. [=In parallel=], run the [=generate key frame algorithm=] with |promise|, |this|'s encoder and |rid|.
 1. Return |promise|.
 
 # Privacy and security considerations # {#privacy}


### PR DESCRIPTION
This follows RTCRtpScripTransformer API.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-insertable-streams/pull/146.html" title="Last updated on Sep 1, 2022, 12:06 PM UTC (88e27d9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/146/ef682af...youennf:88e27d9.html" title="Last updated on Sep 1, 2022, 12:06 PM UTC (88e27d9)">Diff</a>