### PR TITLE
intro: remove funny hats

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -32,27 +32,19 @@ spec:streams; type:interface; text:ReadableStream
 
 # Introduction # {#introduction}
 
-The [[WEBRTC-NV-USE-CASES]] document describes several functions that
-can only be achieved by access to media (requirements N20-N22),
-including, but not limited to:
-* Funny Hats
-* Machine Learning
-* Virtual Reality Gaming
+The [[WEBRTC-NV-USE-CASES]] document describes the use-case of
+    * Untrusted JavaScript Cloud Conferencing
+which requires that the conferencing server does not have access
+to the cleartext media (requirement N27).
 
-These use cases further require that processing can be done in worker
-threads (requirement N23-N24).
-
-Furthermore, the "trusted JavaScript cloud conferencing" use case
-requires such processing to be done on encoded media, not just the raw
-media.
-
-This specification gives an interface inspired by [[WEB-CODECS]] to
-provide access to such functionality while retaining the setup flow of
-RTCPeerConnection.
-
-This iteration of the specification provides access to encoded media,
+This specification provides access to encoded media,
 which is the output of the encoder part of a codec and the input to the
-decoder part of a codec.
+decoder part of a codec which allows the user agent to apply encryption
+locally.
+
+The interface is inspired by [[WEB-CODECS]] to
+provide access to such functionality while retaining the setup flow of
+RTCPeerConnection
 
 # Terminology # {#terminology}
 


### PR DESCRIPTION
and restrict the use-cases to what we know this is being used for primarily.

fixes #122

@alvestrand PTAL.
(and note that N23 + N24 refer to something else entirely [here](https://w3c.github.io/webrtc-nv-use-cases/#requirements*))


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-media-streams/pull/148.html" title="Last updated on Sep 12, 2022, 12:59 PM UTC (3116893)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/148/ef682af...fippo:3116893.html" title="Last updated on Sep 12, 2022, 12:59 PM UTC (3116893)">Diff</a>