### PR TITLE
audio: add rtp sequence number on incoming frames

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -434,7 +434,7 @@ dictionary RTCEncodedAudioFrameMetadata {
     unsigned long synchronizationSource;
     octet payloadType;
     sequence&lt;unsigned long&gt; contributingSources;
-    short? sequenceNumber; // RTP sequence number on incoming frames.
+    short sequenceNumber;
 };
 </pre>
 ### Members ### {#RTCEncodedAudioFrameMetadata-members}
@@ -466,6 +466,15 @@ dictionary RTCEncodedAudioFrameMetadata {
     <dd>
         <p>
             The list of contribution sources (csrc list) as defined in [[RFC3550]].
+        </p>
+    </dd>
+    <dt>
+        <dfn>sequenceNumber</dfn> of type <span class=
+            "idlMemberType">short</span>
+    </dt>
+    <dd>
+        <p>
+            The RTP sequence number as defined in [[RFC3550]]. Only exists for incoming audio frames.
         </p>
     </dd>
 </dl>

--- a/index.bs
+++ b/index.bs
@@ -476,6 +476,9 @@ dictionary RTCEncodedAudioFrameMetadata {
         <p>
             The RTP sequence number as defined in [[RFC3550]]. Only exists for incoming audio frames.
         </p>
+        <p class="note">
+            Comparing two sequence numbers requires serial number arithmetic described in [[RFC1982]].
+        </p>
     </dd>
 </dl>
 

--- a/index.bs
+++ b/index.bs
@@ -434,6 +434,7 @@ dictionary RTCEncodedAudioFrameMetadata {
     unsigned long synchronizationSource;
     octet payloadType;
     sequence&lt;unsigned long&gt; contributingSources;
+    short? sequenceNumber; // RTP sequence number on incoming frames.
 };
 </pre>
 ### Members ### {#RTCEncodedAudioFrameMetadata-members}


### PR DESCRIPTION
where it is easily available.

This is useful in cases where one decodes audio using other means and just wants to grab the encoded frame (similar to what @alvestrand describes [here](https://lists.w3.org/Archives/Public/public-webrtc/2022Aug/0032.html) as "alternative consumers")


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-media-streams/pull/154.html" title="Last updated on Jan 16, 2023, 11:18 AM UTC (ecc99ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/154/c85fc84...fippo:ecc99ce.html" title="Last updated on Jan 16, 2023, 11:18 AM UTC (ecc99ce)">Diff</a>