### PR TITLE
remove contributingSources from VideoFrameMetadata

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -282,7 +282,6 @@ dictionary RTCEncodedVideoFrameMetadata {
     long temporalIndex;
     unsigned long synchronizationSource;
     octet payloadType;
-    sequence&lt;unsigned long&gt; contributingSources;
 };
 
 // New interfaces to define encoded video and audio frames. Will eventually


### PR DESCRIPTION
contributing sources are in general used by audio mixers as described in
  https://datatracker.ietf.org/doc/html/rfc6465
but are not commonly used for video.

Chrome has this in [the IDL](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/peerconnection/rtc_encoded_video_frame_metadata.idl;l=17;bpv=1;bpt=0) but this is not [backed by the implementation](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/peerconnection/rtc_encoded_video_frame.cc;l=40;drc=8d399817282e3c12ed54eb23ec42a5e418298ec6;bpv=1;bpt=1),
Safari has a [TODO](https://github.com/WebKit/WebKit/blob/a121340322ef72e3e303af58db1c88cb23bf397d/Source/WebCore/Modules/mediastream/RTCEncodedVideoFrame.idl#L41) for it so this seems safe to remove.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-media-streams/pull/157.html" title="Last updated on Oct 5, 2022, 8:18 AM UTC (c806ad7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/157/f2797d7...fippo:c806ad7.html" title="Last updated on Oct 5, 2022, 8:18 AM UTC (c806ad7)">Diff</a>