### PR TITLE
Add presentationTimestamp to RTCEncodedVideoFrameMetadata

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -373,8 +373,7 @@ dictionary RTCEncodedVideoFrameMetadata {
     <dd>
         <p>
             The media presentation timestamp (PTS) in microseconds of raw frame, matching the
-	    {{VideoFrame/timestamp}} for raw frames which correspond to this frame and the
-	    {{VideoFrameCallbackMetadata/mediaTime}} given if this frame is decoded and rendererd.
+	    {{VideoFrame/timestamp}} for raw frames which correspond to this frame.
         </p>
     </dd>
 </dl>

--- a/index.bs
+++ b/index.bs
@@ -331,7 +331,7 @@ dictionary RTCEncodedVideoFrameMetadata {
     unsigned long synchronizationSource;
     octet payloadType;
     sequence&lt;unsigned long&gt; contributingSources;
-    long long presentationTimestamp;    // microseconds
+    long long timestamp;    // microseconds
 };
 </pre>
 
@@ -367,7 +367,7 @@ dictionary RTCEncodedVideoFrameMetadata {
         </p>
     </dd>
     <dt>
-        <dfn>presentationTimestamp</dfn> of type <span class=
+        <dfn>timestamp</dfn> of type <span class=
             "idlMemberType">long long</span>
     </dt>
     <dd>

--- a/index.bs
+++ b/index.bs
@@ -330,7 +330,8 @@ dictionary RTCEncodedVideoFrameMetadata {
     unsigned long temporalIndex;
     unsigned long synchronizationSource;
     octet payloadType;
-  sequence&lt;unsigned long&gt; contributingSources;
+    sequence&lt;unsigned long&gt; contributingSources;
+    long long presentationTimestamp;    // microseconds
 };
 </pre>
 
@@ -363,6 +364,17 @@ dictionary RTCEncodedVideoFrameMetadata {
     <dd>
         <p>
             The list of contribution sources (csrc list) as defined in [[RFC3550]].
+        </p>
+    </dd>
+    <dt>
+        <dfn>presentationTimestamp</dfn> of type <span class=
+            "idlMemberType">long long</span>
+    </dt>
+    <dd>
+        <p>
+            The media presentation timestamp (PTS) in microseconds of raw frame, matching the
+	    {{VideoFrame/timestamp}} for raw frames which correspond to this frame and the
+	    {{VideoFrameCallbackMetadata/mediaTime}} given if this frame is decoded and rendererd.
         </p>
     </dd>
 </dl>


### PR DESCRIPTION
Add a captureTimestamp to RTCEncodedVideoFrameMetadata, defined only for local device captures to match the mediaTime as defined in requestVideoFrameCallback() and also match the `timestamp` in WebCodecs VideoFrame and EncodedVideoChunk. This allows apps to match encoded frames after encoding/before decoding with the corresponding raw frames in the [mediacapture-transform](https://www.w3.org/TR/mediacapture-transform/) APIs.

Essentially an adoption of the open https://github.com/w3c/webrtc-encoded-transform/pull/137, incorporating the comments there.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tonyherre/webrtc-encoded-transform/pull/173.html" title="Last updated on Apr 24, 2023, 1:36 PM UTC (f661a21)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/173/5c7ab84...tonyherre:f661a21.html" title="Last updated on Apr 24, 2023, 1:36 PM UTC (f661a21)">Diff</a>