### PR TITLE
Fix bikeshed-isms

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -86,10 +86,10 @@ argument, ensure that the codec is disabled and produces no output.
 At construction of each {{RTCRtpSender}} or {{RTCRtpReceiver}}, run the following steps:
 2. Initialize [=this=].`[[transform]]` to null.
 3. Initialize [=this=].`[[readable]]` to a new {{ReadableStream}}.
-4. <a dfn for="ReadableStream">Set up</a> [=this=].`[[readable]]`. [=this=].`[[readable]]` is provided frames using the [=readEncodedData=] algorithm given |this| as parameter.
+4. <a dfn for="ReadableStream">Set up</a> [=this=].`[[readable]]`. [=this=].`[[readable]]` is provided frames using the [$readEncodedData$] algorithm given |this| as parameter.
 5. Set [=this=].`[[readable]]`.`[[owner]]` to |this|.
 6. Initialize [=this=].`[[writable]]` to a new {{WritableStream}}.
-7. <a dfn for="WritableStream">Set up</a> [=this=].`[[writable]]` with its [=WritableStream/set up/writeAlgorithm=] set to [=writeEncodedData=] given |this| as parameter and its [=WritableStream/set up/sizeAlgorithm=] to an algorithm that returns <code>0</code>.
+7. <a dfn for="WritableStream">Set up</a> [=this=].`[[writable]]` with its [=WritableStream/set up/writeAlgorithm=] set to [$writeEncodedData$] given |this| as parameter and its [=WritableStream/set up/sizeAlgorithm=] to an algorithm that returns <code>0</code>.
     <p class="note">Chunk size is set to 0 to explictly disable streams backpressure on the write side.</p>
 8. Set [=this=].`[[writable]]`.`[[owner]]` to |this|.
 9. Initialize [=this=].`[[pipeToController]]` to null.
@@ -103,7 +103,7 @@ At construction of each {{RTCRtpSender}} or {{RTCRtpReceiver}}, run the followin
 
 ### Stream processing ### {#stream-processing}
 
-The <dfn>readEncodedData</dfn> algorithm is given a |rtcObject| as parameter. It is defined by running the following steps:
+The <dfn abstract-op>readEncodedData</dfn> algorithm is given a |rtcObject| as parameter. It is defined by running the following steps:
 1. Wait for a frame to be produced by |rtcObject|'s encoder if it is a {{RTCRtpSender}} or |rtcObject|'s packetizer if it is a {{RTCRtpReceiver}}.
 1. Increment |rtcObject|.`[[lastEnqueuedFrameCounter]]` by <code>1</code>.
 1. Let |frame| be the newly produced frame.
@@ -111,7 +111,7 @@ The <dfn>readEncodedData</dfn> algorithm is given a |rtcObject| as parameter. It
 1. Set |frame|.`[[counter]]` to |rtcObject|.`[[lastEnqueuedFrameCounter]]`.
 1. [=ReadableStream/Enqueue=] |frame| in |rtcObject|.`[[readable]]`.
 
-The <dfn>writeEncodedData</dfn> algorithm is given a |rtcObject| as parameter and a |frame| as input. It is defined by running the following steps:
+The <dfn abstract-op>writeEncodedData</dfn> algorithm is given a |rtcObject| as parameter and a |frame| as input. It is defined by running the following steps:
 1. If |frame|.`[[owner]]` is not equal to |rtcObject|, abort these steps and return [=a promise resolved with=] undefined. A processor cannot create frames, or move frames between streams.
 1. If |frame|.`[[counter]]` is equal or smaller than |rtcObject|.`[[lastReceivedFrameCounter]]`, abort these steps and return [=a promise resolved with=] undefined. A processor cannot reorder frames, although it may delay them or drop them.
 1. Set |rtcObject|.`[[lastReceivedFrameCounter]]` to |frame|`[[counter]]`.
@@ -123,18 +123,18 @@ The <dfn>writeEncodedData</dfn> algorithm is given a |rtcObject| as parameter an
     * If |rtcObject| is a {{RTCRtpReceiver}}, enqueue |frameCopy| it to |rtcObject|'s decoder, to be processed [=in parallel=].
 1. Return [=a promise resolved with=] undefined.
 
-On sender side, as part of [=readEncodedData=], frames produced by |rtcObject|'s encoder MUST be enqueued in |rtcObject|.`[[readable]]` in the encoder's output order.
-As [=writeEncodedData=] ensures that the transform cannot reorder frames, the encoder's output order is also the order followed by packetizers to generate RTP packets and assign RTP packet sequence numbers.
+On sender side, as part of [$readEncodedData$], frames produced by |rtcObject|'s encoder MUST be enqueued in |rtcObject|.`[[readable]]` in the encoder's output order.
+As [$writeEncodedData$] ensures that the transform cannot reorder frames, the encoder's output order is also the order followed by packetizers to generate RTP packets and assign RTP packet sequence numbers.
 
-On receiver side, as part of [=readEncodedData=], frames produced by |rtcObject|'s packetizer MUST be enqueued in |rtcObject|.`[[readable]]` in the same encoder's output order.
+On receiver side, as part of [$readEncodedData$], frames produced by |rtcObject|'s packetizer MUST be enqueued in |rtcObject|.`[[readable]]` in the same encoder's output order.
 To ensure the order is respected, the depacketizer will typically use RTP packet sequence numbers to reorder RTP packets as needed before enqueuing frames in |rtcObject|.`[[readable]]`.
-As [=writeEncodedData=] ensures that the transform cannot reorder frames, this will be the order expected by |rtcObject|'s decoder.
+As [$writeEncodedData$] ensures that the transform cannot reorder frames, this will be the order expected by |rtcObject|'s decoder.
 
 ## Extension attribute ## {#attribute}
 
 A RTCRtpTransform has two private slots called `[[readable]]` and `[[writable]]`.
 
-Each RTCRtpTransform has an <dfn>association steps</dfn> set, which is empty by default.
+Each RTCRtpTransform has an <dfn abstract-op for=RTCRtpTransform>association steps</dfn> set, which is empty by default.
 
 The <dfn attribute for="RTCRtpSender,RTCRtpReceiver">transform</dfn> getter steps are:
 1. Return [=this=].`[[transform]]`.
@@ -146,14 +146,14 @@ The `transform` setter steps are:
 4. Let |writer| be the result of [=WritableStream/getting a writer=] for |checkedTransform|.`[[writable]]`.
 5. Initialize |newPipeToController| to a new {{AbortController}}.
 6. If [=this=].`[[pipeToController]]` is not null, run the following steps:
-    1. [=AbortSignal/Add=] the [=chain transform algorithm=] to [=this=].`[[pipeToController]]`.signal.
+    1. [=AbortSignal/Add=] the [$chain transform algorithm$] to [=this=].`[[pipeToController]]`.signal.
     2. [=AbortSignal/signal abort=] [=this=].`[[pipeToController]]`.signal.
-7. Else, run the [=chain transform algorithm=] steps.
+7. Else, run the [$chain transform algorithm$] steps.
 8. Set [=this=].`[[pipeToController]]` to |newPipeToController|.
 9. Set [=this=].`[[transform]]` to |transform|.
-10. Run the steps in the set of [=association steps=] of |transform| with [=this=].
+10. Run the steps in the set of [$association steps$] of |transform| with [=this=].
 
-The <dfn>chain transform algorithm</dfn> steps are defined as:
+The <dfn abstract-op>chain transform algorithm</dfn> steps are defined as:
 1. If |newPipeToController| is [=AbortSignal/aborted=], abort these steps.
 2. [=ReadableStreamDefaultReader/Release=] |reader|.
 3. [=WritableStreamDefaultWriter/Release=] |writer|.
@@ -267,7 +267,7 @@ The <dfn method for="SFrameTransform">setEncryptionKey(|key|, |keyID|)</dfn> met
 
 # RTCRtpScriptTransform # {#scriptTransform}
 
-## <dfn>RTCEncodedVideoFrameType</dfn> dictionary ## {#RTCEncodedVideoFrameType}
+## <dfn enum>RTCEncodedVideoFrameType</dfn> dictionary ## {#RTCEncodedVideoFrameType}
 <pre class="idl">
 // New enum for video frame types. Will eventually re-use the equivalent defined
 // by WebCodecs.
@@ -277,8 +277,7 @@ enum RTCEncodedVideoFrameType {
     "delta",
 };
 </pre>
-<table data-link-for="RTCEncodedVideoFrameType" data-dfn-for=
-    "RTCEncodedVideoFrameType" class="simple">
+<table dfn-for="RTCEncodedVideoFrameType" class="simple">
 	<caption>Enumeration description</caption>
     <thead>
         <tr>
@@ -288,7 +287,7 @@ enum RTCEncodedVideoFrameType {
     <tbody>
         <tr>
             <td>
-                <dfn data-idl="">empty</dfn>
+                <dfn enum-value>empty</dfn>
             </td>
             <td>
                 <p>
@@ -298,7 +297,7 @@ enum RTCEncodedVideoFrameType {
         </tr>
         <tr>
             <td>
-                <dfn data-idl="">key</dfn>
+                <dfn enum-value>key</dfn>
             </td>
             <td>
                 <p>
@@ -308,7 +307,7 @@ enum RTCEncodedVideoFrameType {
         </tr>
         <tr>
             <td>
-                <dfn data-idl="">delta</dfn>
+                <dfn enum-value>delta</dfn>
             </td>
             <td>
                 <p>
@@ -319,7 +318,7 @@ enum RTCEncodedVideoFrameType {
     </tbody>
 </table>
 
-## <dfn>RTCEncodedVideoFrameMetadata</dfn> dictionary ## {#RTCEncodedVideoFrameMetadata}
+## <dfn dictionary>RTCEncodedVideoFrameMetadata</dfn> dictionary ## {#RTCEncodedVideoFrameMetadata}
 <pre class="idl">
 dictionary RTCEncodedVideoFrameMetadata {
     unsigned long long frameId;
@@ -335,11 +334,10 @@ dictionary RTCEncodedVideoFrameMetadata {
 </pre>
 
 ### Members ### {#RTCEncodedVideoFrameMetadata-members}
-<dl data-link-for="RTCEncodedVideoFrameMetadata"
-        data-dfn-for="RTCEncodedVideoFrameMetadata"
-        class="dictionary-members">
+
+<dl dfn-for="RTCEncodedVideoFrameMetadata" class="dictionary-members">
     <dt>
-        <dfn>synchronizationSource</dfn> of type <span class="idlMemberType">unsigned long</span>
+        <dfn dict-member>synchronizationSource</dfn> of type <span class="idlMemberType">unsigned long</span>
     </dt>
     <dd>
         <p>
@@ -348,7 +346,7 @@ dictionary RTCEncodedVideoFrameMetadata {
         </p>
     </dd>
     <dt>
-        <dfn>payloadType</dfn> of type <span class="idlMemberType">octet</span>
+        <dfn dict-member>payloadType</dfn> of type <span class="idlMemberType">octet</span>
     </dt>
     <dd>
         <p>
@@ -357,7 +355,7 @@ dictionary RTCEncodedVideoFrameMetadata {
         </p>
     </dd>
     <dt>
-        <dfn>contributingSources</dfn> of type <span class=
+        <dfn dict-member>contributingSources</dfn> of type <span class=
             "idlMemberType">sequence&lt;unsigned long&gt;</span>
     </dt>
     <dd>
@@ -368,7 +366,7 @@ dictionary RTCEncodedVideoFrameMetadata {
 </dl>
 
 
-## <dfn>RTCEncodedVideoFrame</dfn> interface ## {#RTCEncodedVideoFrame-interface}
+## <dfn interface>RTCEncodedVideoFrame</dfn> interface ## {#RTCEncodedVideoFrame-interface}
 <pre class="idl">
 // New interfaces to define encoded video and audio frames. Will eventually
 // re-use or extend the equivalent defined in WebCodecs.
@@ -382,11 +380,9 @@ interface RTCEncodedVideoFrame {
 </pre>
 
 ### Members ### {#RTCEncodedVideoFrame-members}
-<dl data-link-for="RTCEncodedVideoFrame"
-        data-dfn-for="RTCEncodedVideoFrame"
-        class="dictionary-members">
+<dl dfn-for="RTCEncodedVideoFrame" class="dictionary-members">
     <dt>
-        <dfn>type</dfn> of type <span class="idlMemberType">RTCEncodedVideoFrameType</span>
+        <dfn attribute>type</dfn> of type <span class="idlMemberType">RTCEncodedVideoFrameType</span>
     </dt>
     <dd>
         <p>
@@ -396,7 +392,7 @@ interface RTCEncodedVideoFrame {
     </dd>
 
     <dt>
-        <dfn>timestamp</dfn> of type <span class="idlMemberType">unsigned long</span>
+        <dfn attribute>timestamp</dfn> of type <span class="idlMemberType">unsigned long</span>
     </dt>
     <dd>
         <p>
@@ -405,7 +401,7 @@ interface RTCEncodedVideoFrame {
         </p>
     </dd>
     <dt>
-        <dfn>data</dfn> of type <span class="idlMemberType">ArrayBuffer</span>
+        <dfn attribute>data</dfn> of type <span class="idlMemberType">ArrayBuffer</span>
     </dt>
     <dd>
         <p>
@@ -415,11 +411,9 @@ interface RTCEncodedVideoFrame {
 </dl>
 
 ### Methods ### {#RTCEncodedVideoFrame-methods}
-<dl data-link-for="RTCEncodedVideoFrame"
-        data-dfn-for="RTCEncodedVideoFrame"
-        class="dictionary-members">
+<dl dfn-for="RTCEncodedVideoFrame" class="dictionary-members">
     <dt>
-        <dfn data-dfn-for="RTCEncodedVideoFrame" data-dfn-type="method">getMetadata()</dfn>
+        <dfn for="RTCEncodedVideoFrame" method>getMetadata()</dfn>
     </dt>
     <dd>
         <p>
@@ -428,7 +422,7 @@ interface RTCEncodedVideoFrame {
     </dd>
 </dl>
 
-## <dfn>RTCEncodedAudioFrameMetadata</dfn> dictionary ## {#RTCEncodedAudioFrameMetadata}
+## <dfn dictionary>RTCEncodedAudioFrameMetadata</dfn> dictionary ## {#RTCEncodedAudioFrameMetadata}
 <pre class="idl">
 dictionary RTCEncodedAudioFrameMetadata {
     unsigned long synchronizationSource;
@@ -438,11 +432,9 @@ dictionary RTCEncodedAudioFrameMetadata {
 };
 </pre>
 ### Members ### {#RTCEncodedAudioFrameMetadata-members}
-<dl data-link-for="RTCEncodedAudioFrameMetadata"
-        data-dfn-for="RTCEncodedAudioFrameMetadata"
-        class="dictionary-members">
+<dl dfn-for="RTCEncodedAudioFrameMetadata" class="dictionary-members">
     <dt>
-        <dfn>synchronizationSource</dfn> of type <span class="idlMemberType">unsigned long</span>
+        <dfn dict-member>synchronizationSource</dfn> of type <span class="idlMemberType">unsigned long</span>
     </dt>
     <dd>
         <p>
@@ -451,7 +443,7 @@ dictionary RTCEncodedAudioFrameMetadata {
         </p>
     </dd>
     <dt>
-        <dfn>payloadType</dfn> of type <span class="idlMemberType">octet</span>
+        <dfn dict-member>payloadType</dfn> of type <span class="idlMemberType">octet</span>
     </dt>
     <dd>
         <p>
@@ -460,7 +452,7 @@ dictionary RTCEncodedAudioFrameMetadata {
         </p>
     </dd>
     <dt>
-        <dfn>contributingSources</dfn> of type <span class=
+        <dfn dict-member>contributingSources</dfn> of type <span class=
             "idlMemberType">sequence&lt;unsigned long&gt;</span>
     </dt>
     <dd>
@@ -469,7 +461,7 @@ dictionary RTCEncodedAudioFrameMetadata {
         </p>
     </dd>
     <dt>
-        <dfn>sequenceNumber</dfn> of type <span class=
+        <dfn dict-member>sequenceNumber</dfn> of type <span class=
             "idlMemberType">short</span>
     </dt>
     <dd>
@@ -482,7 +474,7 @@ dictionary RTCEncodedAudioFrameMetadata {
     </dd>
 </dl>
 
-## <dfn>RTCEncodedAudioFrame</dfn> interface ## {#RTCEncodedAudioFrame-interface}
+## <dfn interface>RTCEncodedAudioFrame</dfn> interface ## {#RTCEncodedAudioFrame-interface}
 <pre class="idl">
 [Exposed=(Window,DedicatedWorker)]
 interface RTCEncodedAudioFrame {
@@ -493,11 +485,9 @@ interface RTCEncodedAudioFrame {
 </pre>
 
 ### Members ### {#RTCEncodedAudioFrame-members}
-<dl data-link-for="RTCEncodedAudioFrame"
-        data-dfn-for="RTCEncodedAudioFrame"
-        class="dictionary-members">
+<dl dfn-for="RTCEncodedAudioFrame" class="dictionary-members">
     <dt>
-        <dfn>timestamp</dfn> of type <span class="idlMemberType">unsigned long</span>
+        <dfn attribute>timestamp</dfn> of type <span class="idlMemberType">unsigned long</span>
     </dt>
     <dd>
         <p>
@@ -506,7 +496,7 @@ interface RTCEncodedAudioFrame {
         </p>
     </dd>
     <dt>
-        <dfn>data</dfn> of type <span class="idlMemberType">ArrayBuffer</span>
+        <dfn attribute>data</dfn> of type <span class="idlMemberType">ArrayBuffer</span>
     </dt>
     <dd>
         <p>
@@ -516,11 +506,9 @@ interface RTCEncodedAudioFrame {
 </dl>
 
 ### Methods ### {#RTCEncodedAudioFrame-methods}
-<dl data-link-for="RTCEncodedAudioFrame"
-        data-dfn-for="RTCEncodedAudioFrame"
-        class="dictionary-members">
+<dl dfn-for="RTCEncodedAudioFrame" class="dictionary-members">
     <dt>
-        <dfn data-dfn-for="RTCEncodedAudioFrame" data-dfn-type="method">getMetadata()</dfn>
+        <dfn for="RTCEncodedAudioFrame" method>getMetadata()</dfn>
     </dt>
     <dd>
         <p>
@@ -579,8 +567,8 @@ The <dfn constructor for="RTCRtpScriptTransform" lt="RTCRtpScriptTransform(worke
 
 // FIXME: Describe error handling (worker closing flag true at RTCRtpScriptTransform creation time. And worker being terminated while transform is processing data).
 
-Each RTCRtpScriptTransform has the following set of [=association steps=], given |rtcObject|:
-1. Let |transform| be the {{RTCRtpScriptTransform}} object that owns the [=association steps=].
+Each RTCRtpScriptTransform has the following set of [$association steps$], given |rtcObject|:
+1. Let |transform| be the {{RTCRtpScriptTransform}} object that owns the [$association steps$].
 1. Let |encoder| be |rtcObject|'s encoder if |rtcObject| is a {{RTCRtpSender}} or undefined otherwise.
 1. Let |depacketizer| be |rtcObject|'s depacketizer if |rtcObject| is a {{RTCRtpReceiver}} or undefined otherwise.
 1. [=Queue a task=] on the DOM manipulation [=task source=] |worker|'s global scope to run the following steps:
@@ -590,12 +578,12 @@ Each RTCRtpScriptTransform has the following set of [=association steps=], given
 
 The <dfn method for="RTCRtpScriptTransformer">generateKeyFrame(|rid|)</dfn> method steps are:
 1. Let |promise| be a new promise.
-1. Run the [=generate key frame algorithm=] with |promise|, |this|.`[[encoder]]` and |rid|.
+1. Run the [$generate key frame algorithm$] with |promise|, |this|.`[[encoder]]` and |rid|.
 1. Return |promise|.
 
 The <dfn method for="RTCRtpScriptTransformer">sendKeyFrameRequest()</dfn> method steps are:
 1. Let |promise| be a new promise.
-1. Run the [=send request key frame algorithm=] with |promise| and |this|.`[[depacketizer]]`.
+1. Run the [$send request key frame algorithm$] with |promise| and |this|.`[[depacketizer]]`.
 1. Return |promise|.
 
 ## Attributes ## {#RTCRtpScriptTransformer-attributes}
@@ -615,7 +603,7 @@ The <dfn attribute for="RTCRtpScriptTransformer">writable</dfn> getter steps are
 
 ## KeyFrame Algorithms ## {#KeyFrame-algorithms}
 
-The <dfn>generate key frame algorithm</dfn>, given |promise|, |encoder| and |rid|, is defined by running these steps:
+The <dfn abstract-op>generate key frame algorithm</dfn>, given |promise|, |encoder| and |rid|, is defined by running these steps:
 1. If |encoder| is undefined, reject |promise| with {{InvalidStateError}}, abort these steps.
 1. If |encoder| is not processing video frames, reject |promise| with {{InvalidStateError}}, abort these steps.
 1. If |rid| is defined, validate its value. If invalid, reject |promise| with {{NotAllowedError}} and abort these steps.
@@ -647,7 +635,7 @@ By resolving the promises just before enqueuing the corresponding key frame in a
 the resolution callbacks of the promises are always executed just before the corresponding key frame is exposed.
 If the promise is associated to several rid values, it will be resolved when the first key frame corresponding to one the rid value is enqueued.
 
-The <dfn>send request key frame algorithm</dfn>, given |promise| and |depacketizer|, is defined by running these steps:
+The <dfn abstract-op>send request key frame algorithm</dfn>, given |promise| and |depacketizer|, is defined by running these steps:
 1. If |depacketizer| is undefined, reject |promise| with {{InvalidStateError}}, abort these steps.
 1. If |depacketizer| is not processing video packets, reject |promise| with {{InvalidStateError}}, abort these steps.
 1. [=In parallel=], run the following steps:
@@ -671,7 +659,7 @@ partial interface RTCRtpSender {
 The <dfn method for="RTCRtpSender">generateKeyFrame(|rids|)</dfn> method steps are:
 
 1. Let |promise| be a new promise.
-1. [=In parallel=], run the [=generate key frame algorithm=] with |promise|, |this|'s encoder and |rids|.
+1. [=In parallel=], run the [$generate key frame algorithm$] with |promise|, |this|'s encoder and |rids|.
 1. Return |promise|.
 
 # Privacy and security considerations # {#privacy}


### PR DESCRIPTION
bikeshed seems to not like multi-line attributes (possibly when used with markdown) also correctly set type of several definitions


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/pull/176.html" title="Last updated on Mar 16, 2023, 2:34 PM UTC (1a53af2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/176/5c7ab84...1a53af2.html" title="Last updated on Mar 16, 2023, 2:34 PM UTC (1a53af2)">Diff</a>