### PR TITLE
fix RTCEncodedVideoFrameMeta contributingSources indent

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -330,7 +330,7 @@ dictionary RTCEncodedVideoFrameMetadata {
     unsigned long temporalIndex;
     unsigned long synchronizationSource;
     octet payloadType;
-  sequence&lt;unsigned long&gt; contributingSources;
+    sequence&lt;unsigned long&gt; contributingSources;
 };
 </pre>
 


### PR DESCRIPTION
This was painful to look at in https://docs.google.com/presentation/d/1pt1iEtqv49etzQ_u8E4QOpE3MUqQHbH6H8KlSW7MpfA/edit#slide=id.g22f9b24c9ec_0_0 ;-)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-media-streams/pull/177.html" title="Last updated on Apr 18, 2023, 4:57 PM UTC (68187c3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/177/5c7ab84...fippo:68187c3.html" title="Last updated on Apr 18, 2023, 4:57 PM UTC (68187c3)">Diff</a>