### PR TITLE
Editorial: Call AbortController's "signal abort" instead of AbortSignal's

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -147,14 +147,14 @@ The `transform` setter steps are:
 5. Initialize |newPipeToController| to a new {{AbortController}}.
 6. If [=this=].`[[pipeToController]]` is not null, run the following steps:
     1. [=AbortSignal/Add=] the [$chain transform algorithm$] to [=this=].`[[pipeToController]]`.signal.
-    2. [=AbortSignal/signal abort=] [=this=].`[[pipeToController]]`.signal.
+    2. [=AbortController/signal abort=] on [=this=].`[[pipeToController]]`.
 7. Else, run the [$chain transform algorithm$] steps.
 8. Set [=this=].`[[pipeToController]]` to |newPipeToController|.
 9. Set [=this=].`[[transform]]` to |transform|.
 10. Run the steps in the set of [$association steps$] of |transform| with [=this=].
 
 The <dfn abstract-op>chain transform algorithm</dfn> steps are defined as:
-1. If |newPipeToController| is [=AbortSignal/aborted=], abort these steps.
+1. If |newPipeToController|.signal is [=AbortSignal/aborted=], abort these steps.
 2. [=ReadableStreamDefaultReader/Release=] |reader|.
 3. [=WritableStreamDefaultWriter/Release=] |writer|.
 4. Assert that |newPipeToController| is the same object as |rtcObject|.`[[pipeToController]]`.


### PR DESCRIPTION
For https://github.com/whatwg/dom/issues/1194. This replaces calling "signal abort" on `pipeToController`'s signal with calling "signal abort" on `pipeToController` (an `AbortController`), which is functionally equivalent. This also fixes a bug with checking "aborted" on a controller rather than its signal.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shaseley/webrtc-encoded-transform/pull/178.html" title="Last updated on May 23, 2023, 11:55 PM UTC (5e82900)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/178/915870d...shaseley:5e82900.html" title="Last updated on May 23, 2023, 11:55 PM UTC (5e82900)">Diff</a>