### PR TITLE
Make SFrameTransform inherit from EventTarget

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -188,7 +188,7 @@ typedef [EnforceRange] unsigned long long SmallCryptoKeyID;
 typedef (SmallCryptoKeyID or bigint) CryptoKeyID;
 
 [Exposed=(Window,DedicatedWorker)]
-interface SFrameTransform {
+interface SFrameTransform : EventTarget {
     constructor(optional SFrameTransformOptions options = {});
     Promise<undefined> setEncryptionKey(CryptoKey key, optional CryptoKeyID keyID);
     attribute EventHandler onerror;


### PR DESCRIPTION
Needed for the `error` event. Fixes #175.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/webrtc-encoded-transform/pull/179.html" title="Last updated on May 24, 2023, 12:53 PM UTC (e22e787)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/179/915870d...tidoust:e22e787.html" title="Last updated on May 24, 2023, 12:53 PM UTC (e22e787)">Diff</a>