### PR TITLE
Add Serializable attributes to encoded video frames

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -564,8 +564,7 @@ Their deserialization steps, given |serialized|, |value| and |realm|, are:
 1. Set |value|'s metadata to the platform object representation of |serialized|.`[[metadata]]`
 1. Set |value|.`[[data]]` to |serialized|.`[[data]]`.
 
-// New interfaces to expose JavaScript-based transforms.
-##Interfaces
+## Interfaces ## {#RTCRtpScriptTransformer-interfaces}
 <pre class="idl">
 [Exposed=DedicatedWorker]
 interface RTCTransformEvent : Event {

--- a/index.bs
+++ b/index.bs
@@ -338,7 +338,7 @@ dictionary RTCEncodedVideoFrameMetadata {
 
 <dl dfn-for="RTCEncodedVideoFrameMetadata" class="dictionary-members">
     <dt>
-        <dfn dict-member>synchronizationSource</dfn> of type <span class="idlMemberType">unsigned long</span>
+        <dfn dict-member>synchronizationSource</dfn> <span class="idlMemberType">unsigned long</span>
     </dt>
     <dd>
         <p>
@@ -347,7 +347,7 @@ dictionary RTCEncodedVideoFrameMetadata {
         </p>
     </dd>
     <dt>
-        <dfn dict-member>payloadType</dfn> of type <span class="idlMemberType">octet</span>
+        <dfn dict-member>payloadType</dfn> <span class="idlMemberType">octet</span>
     </dt>
     <dd>
         <p>
@@ -356,7 +356,7 @@ dictionary RTCEncodedVideoFrameMetadata {
         </p>
     </dd>
     <dt>
-        <dfn dict-member>contributingSources</dfn> of type <span class=
+        <dfn dict-member>contributingSources</dfn> <span class=
             "idlMemberType">sequence&lt;unsigned long&gt;</span>
     </dt>
     <dd>
@@ -365,7 +365,7 @@ dictionary RTCEncodedVideoFrameMetadata {
         </p>
     </dd>
     <dt>
-        <dfn>timestamp</dfn> of type <span class=
+        <dfn>timestamp</dfn> <span class=
             "idlMemberType">long long</span>
     </dt>
     <dd>
@@ -393,7 +393,7 @@ interface RTCEncodedVideoFrame {
 ### Members ### {#RTCEncodedVideoFrame-members}
 <dl dfn-for="RTCEncodedVideoFrame" class="dictionary-members">
     <dt>
-        <dfn attribute>type</dfn> of type <span class="idlMemberType">RTCEncodedVideoFrameType</span>
+        <dfn attribute>type</dfn> <span class="idlMemberType">RTCEncodedVideoFrameType</span>
     </dt>
     <dd>
         <p>
@@ -403,7 +403,7 @@ interface RTCEncodedVideoFrame {
     </dd>
 
     <dt>
-        <dfn attribute>timestamp</dfn> of type <span class="idlMemberType">unsigned long</span>
+        <dfn attribute>timestamp</dfn> <span class="idlMemberType">unsigned long</span>
     </dt>
     <dd>
         <p>
@@ -412,7 +412,7 @@ interface RTCEncodedVideoFrame {
         </p>
     </dd>
     <dt>
-        <dfn attribute>data</dfn> of type <span class="idlMemberType">ArrayBuffer</span>
+        <dfn attribute>data</dfn> <span class="idlMemberType">ArrayBuffer</span>
     </dt>
     <dd>
         <p>
@@ -436,21 +436,25 @@ interface RTCEncodedVideoFrame {
 ### Serialization ### {#RTCEncodedVideoFrame-serialization}
 
 {{RTCEncodedVideoFrame}} objects are serializable objects [[HTML]].
-Their serialization steps, given |value|, |serialized|, and |forStorage|, are:
+Their [=serialization steps=], given |value|, |serialized|, and |forStorage|, are:
 
-1. If |forStorage| is true, then throw a "DataCloneError" DOMException.
+1. If |forStorage| is true, then throw a {{DataCloneError}}.
+1. Set |serialized|.`[[type]]` to the value of |value|.{{RTCEncodedVideoFrame/type}}
+1. Set |serialized|.`[[timestamp]]` to the value of |value|.{{RTCEncodedVideoFrame/timestamp}}
 1. Set |serialized|.`[[metadata]]` to an internal representation of |value|'s metadata.
 1. Set |serialized|.`[[data]]` to |value|.`[[data]]`
 
-Their deserialization steps, given |serialized|, |value| and |realm|, are:
+Their [=deserialization steps=], given |serialized|, |value| and |realm|, are:
 
+1. Set |value|.{{RTCEncodedVideoFrame/type}} to |serialized|.`[[type]]`
+1. Set |value|.{{RTCEncodedVideoFrame/timestamp}} to |serialized|.`[[timestamp]]`
 1. Set |value|'s metadata to the platform object representation of |serialized|.`[[metadata]]`
 1. Set |value|.`[[data]]` to |serialized|.`[[data]]`.
 
 <p class="note">
 The internal form of a serialized RTCEncodedVideoFrame is not observable;
 it is defined chiefly so that it can be used with frame cloning in the
-[$writeEncodedData$] algortihm and in the StructuredClone operation.
+[$writeEncodedData$] algorithm and in the {{WindowOrWorkerGlobalScope/structuredClone()}} operation.
 An implementation is therefore free to choose whatever method works best.
 </p>
 
@@ -466,7 +470,7 @@ dictionary RTCEncodedAudioFrameMetadata {
 ### Members ### {#RTCEncodedAudioFrameMetadata-members}
 <dl dfn-for="RTCEncodedAudioFrameMetadata" class="dictionary-members">
     <dt>
-        <dfn dict-member>synchronizationSource</dfn> of type <span class="idlMemberType">unsigned long</span>
+        <dfn dict-member>synchronizationSource</dfn> <span class="idlMemberType">unsigned long</span>
     </dt>
     <dd>
         <p>
@@ -475,7 +479,7 @@ dictionary RTCEncodedAudioFrameMetadata {
         </p>
     </dd>
     <dt>
-        <dfn dict-member>payloadType</dfn> of type <span class="idlMemberType">octet</span>
+        <dfn dict-member>payloadType</dfn> <span class="idlMemberType">octet</span>
     </dt>
     <dd>
         <p>
@@ -484,7 +488,7 @@ dictionary RTCEncodedAudioFrameMetadata {
         </p>
     </dd>
     <dt>
-        <dfn dict-member>contributingSources</dfn> of type <span class=
+        <dfn dict-member>contributingSources</dfn> <span class=
             "idlMemberType">sequence&lt;unsigned long&gt;</span>
     </dt>
     <dd>
@@ -493,7 +497,7 @@ dictionary RTCEncodedAudioFrameMetadata {
         </p>
     </dd>
     <dt>
-        <dfn dict-member>sequenceNumber</dfn> of type <span class=
+        <dfn dict-member>sequenceNumber</dfn> <span class=
             "idlMemberType">short</span>
     </dt>
     <dd>
@@ -519,7 +523,7 @@ interface RTCEncodedAudioFrame {
 ### Members ### {#RTCEncodedAudioFrame-members}
 <dl dfn-for="RTCEncodedAudioFrame" class="dictionary-members">
     <dt>
-        <dfn attribute>timestamp</dfn> of type <span class="idlMemberType">unsigned long</span>
+        <dfn attribute>timestamp</dfn> <span class="idlMemberType">unsigned long</span>
     </dt>
     <dd>
         <p>
@@ -528,7 +532,7 @@ interface RTCEncodedAudioFrame {
         </p>
     </dd>
     <dt>
-        <dfn attribute>data</dfn> of type <span class="idlMemberType">ArrayBuffer</span>
+        <dfn attribute>data</dfn> <span class="idlMemberType">ArrayBuffer</span>
     </dt>
     <dd>
         <p>
@@ -553,14 +557,16 @@ interface RTCEncodedAudioFrame {
 ### Serialization ### {#RTCEncodedAudioFrame-serialization}
 
 {{RTCEncodedAudioFrame}} objects are serializable objects [[HTML]].
-Their serialization steps, given |value|, |serialized|, and |forStorage|, are:
+Their [=serialization steps=], given |value|, |serialized|, and |forStorage|, are:
 
-1. If |forStorage| is true, then throw a "DataCloneError" DOMException.
+1. If |forStorage| is true, then throw a {{DataCloneError}}.
+1. Set |serialized|.`[[timestamp]]` to the value of |value|.{{RTCEncodedAudioFrame/timestamp}}
 1. Set |serialized|.`[[metadata]]` to an internal representation of |value|'s metadata.
 1. Set |serialized|.`[[data]]` to |value|.`[[data]]`
 
-Their deserialization steps, given |serialized|, |value| and |realm|, are:
+Their [=deserialization steps=], given |serialized|, |value| and |realm|, are:
 
+1. Set |value|.{{RTCEncodedAudioFrame/timestamp}} to |serialized|.`[[timestamp]]`
 1. Set |value|'s metadata to the platform object representation of |serialized|.`[[metadata]]`
 1. Set |value|.`[[data]]` to |serialized|.`[[data]]`.
 

--- a/index.bs
+++ b/index.bs
@@ -381,7 +381,7 @@ dictionary RTCEncodedVideoFrameMetadata {
 <pre class="idl">
 // New interfaces to define encoded video and audio frames. Will eventually
 // re-use or extend the equivalent defined in WebCodecs.
-[Exposed=(Window,DedicatedWorker)]
+[Exposed=(Window,DedicatedWorker), Serializable]
 interface RTCEncodedVideoFrame {
     readonly attribute RTCEncodedVideoFrameType type;
     readonly attribute unsigned long timestamp;
@@ -487,7 +487,7 @@ dictionary RTCEncodedAudioFrameMetadata {
 
 ## <dfn interface>RTCEncodedAudioFrame</dfn> interface ## {#RTCEncodedAudioFrame-interface}
 <pre class="idl">
-[Exposed=(Window,DedicatedWorker)]
+[Exposed=(Window,DedicatedWorker), Serializable]
 interface RTCEncodedAudioFrame {
     readonly attribute unsigned long timestamp;
     attribute ArrayBuffer data;

--- a/index.bs
+++ b/index.bs
@@ -278,7 +278,7 @@ enum RTCEncodedVideoFrameType {
 };
 </pre>
 <table dfn-for="RTCEncodedVideoFrameType" class="simple">
-	<caption>Enumeration description</caption>
+  <caption>Enumeration description</caption>
     <thead>
         <tr>
             <th>Enum value</th><th>Description</th>
@@ -371,7 +371,7 @@ dictionary RTCEncodedVideoFrameMetadata {
     <dd>
         <p>
             The media presentation timestamp (PTS) in microseconds of raw frame, matching the
-	    {{VideoFrame/timestamp}} for raw frames which correspond to this frame.
+      {{VideoFrame/timestamp}} for raw frames which correspond to this frame.
         </p>
     </dd>
 </dl>
@@ -432,6 +432,27 @@ interface RTCEncodedVideoFrame {
         </p>
     </dd>
 </dl>
+
+### Serialization ### {#RTCEncodedVideoFrame-serialization}
+
+{{RTCEncodedVideoFrame}} objects are serializable objects [[HTML]].
+Their serialization steps, given |value|, |serialized|, and |forStorage|, are:
+
+1. If |forStorage| is true, then throw a "DataCloneError" DOMException.
+1. Set |serialized|.`[[metadata]]` to an internal representation of |value|'s metadata.
+1. Set |serialized|.`[[data]]` to |value|.`[[data]]`
+
+Their deserialization steps, given |serialized|, |value| and |realm|, are:
+
+1. Set |value|'s metadata to the platform object representation of |serialized|.`[[metadata]]`
+1. Set |value|.`[[data]]` to |serialized|.`[[data]]`.
+
+<p class="note">
+The internal form of a serialized RTCEncodedVideoFrame is not observable;
+it is defined chiefly so that it can be used with frame cloning in the
+[$writeEncodedData$] algortihm and in the StructuredClone operation.
+An implementation is therefore free to choose whatever method works best.
+</p>
 
 ## <dfn dictionary>RTCEncodedAudioFrameMetadata</dfn> dictionary ## {#RTCEncodedAudioFrameMetadata}
 <pre class="idl">
@@ -528,6 +549,20 @@ interface RTCEncodedAudioFrame {
     </dd>
 </dl>
 
+
+### Serialization ### {#RTCEncodedAudioFrame-serialization}
+
+{{RTCEncodedAudioFrame}} objects are serializable objects [[HTML]].
+Their serialization steps, given |value|, |serialized|, and |forStorage|, are:
+
+1. If |forStorage| is true, then throw a "DataCloneError" DOMException.
+1. Set |serialized|.`[[metadata]]` to an internal representation of |value|'s metadata.
+1. Set |serialized|.`[[data]]` to |value|.`[[data]]`
+
+Their deserialization steps, given |serialized|, |value| and |realm|, are:
+
+1. Set |value|'s metadata to the platform object representation of |serialized|.`[[metadata]]`
+1. Set |value|.`[[data]]` to |serialized|.`[[data]]`.
 
 // New interfaces to expose JavaScript-based transforms.
 ##Interfaces


### PR DESCRIPTION
Fixes #181


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/pull/182.html" title="Last updated on Sep 22, 2023, 1:17 PM UTC (0c3c5ea)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/182/49f981b...0c3c5ea.html" title="Last updated on Sep 22, 2023, 1:17 PM UTC (0c3c5ea)">Diff</a>