### PR TITLE
Editorial: Use AbortController/signal to access controller's signal

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -99,7 +99,7 @@ At construction of each {{RTCRtpSender}} or {{RTCRtpReceiver}}, run the followin
     1. If [=this=].`[[pipeToController]]` is not null, abort these steps.
     2. Set [=this=].`[[pipeToController]]` to a new {{AbortController}}.
     <!-- FIXME: Use pipeTo algorithm when available. -->
-    3. Call <a href="https://streams.spec.whatwg.org/#readable-stream-pipe-to">pipeTo</a> with [=this=].`[[readable]]`, [=this=].`[[writable]]`, preventClose equal to true, preventAbort equal to true, preventCancel equal to true and [=this=].`[[pipeToController]]`.signal.
+    3. Call <a href="https://streams.spec.whatwg.org/#readable-stream-pipe-to">pipeTo</a> with [=this=].`[[readable]]`, [=this=].`[[writable]]`, preventClose equal to true, preventAbort equal to true, preventCancel equal to true and [=this=].`[[pipeToController]]`'s [=AbortController/signal=].
 
 ### Stream processing ### {#stream-processing}
 
@@ -146,7 +146,7 @@ The `transform` setter steps are:
 4. Let |writer| be the result of [=WritableStream/getting a writer=] for |checkedTransform|.`[[writable]]`.
 5. Initialize |newPipeToController| to a new {{AbortController}}.
 6. If [=this=].`[[pipeToController]]` is not null, run the following steps:
-    1. [=AbortSignal/Add=] the [$chain transform algorithm$] to [=this=].`[[pipeToController]]`.signal.
+    1. [=AbortSignal/Add=] the [$chain transform algorithm$] to [=this=].`[[pipeToController]]`'s [=AbortController/signal=].
     2. [=AbortController/signal abort=] on [=this=].`[[pipeToController]]`.
 7. Else, run the [$chain transform algorithm$] steps.
 8. Set [=this=].`[[pipeToController]]` to |newPipeToController|.
@@ -154,13 +154,13 @@ The `transform` setter steps are:
 10. Run the steps in the set of [$association steps$] of |transform| with [=this=].
 
 The <dfn abstract-op>chain transform algorithm</dfn> steps are defined as:
-1. If |newPipeToController|.signal is [=AbortSignal/aborted=], abort these steps.
+1. If |newPipeToController|'s [=AbortController/signal=] is [=AbortSignal/aborted=], abort these steps.
 2. [=ReadableStreamDefaultReader/Release=] |reader|.
 3. [=WritableStreamDefaultWriter/Release=] |writer|.
 4. Assert that |newPipeToController| is the same object as |rtcObject|.`[[pipeToController]]`.
 <!-- FIXME: Use pipeTo algorithm when available. -->
-5. Call <a href="https://streams.spec.whatwg.org/#readable-stream-pipe-to">pipeTo</a> with |rtcObject|.`[[readable]]`, |checkedTransform|.`[[writable]]`, preventClose equal to false, preventAbort equal to false, preventCancel equal to true and |newPipeToController|.signal.
-6. Call <a href="https://streams.spec.whatwg.org/#readable-stream-pipe-to">pipeTo</a> with |checkedTransform|.`[[readable]]`, |rtcObject|.`[[writable]]`, preventClose equal to true, preventAbort equal to true, preventCancel equal to false and |newPipeToController|.signal.
+5. Call <a href="https://streams.spec.whatwg.org/#readable-stream-pipe-to">pipeTo</a> with |rtcObject|.`[[readable]]`, |checkedTransform|.`[[writable]]`, preventClose equal to false, preventAbort equal to false, preventCancel equal to true and |newPipeToController|'s [=AbortController/signal=].
+6. Call <a href="https://streams.spec.whatwg.org/#readable-stream-pipe-to">pipeTo</a> with |checkedTransform|.`[[readable]]`, |rtcObject|.`[[writable]]`, preventClose equal to true, preventAbort equal to true, preventCancel equal to false and |newPipeToController|'s [=AbortController/signal=].
 
 This algorithm is defined so that transforms can be updated dynamically.
 There is no guarantee on which frame will happen the switch from the previous transform to the new transform.


### PR DESCRIPTION
Following up on work related to https://github.com/w3c/webrtc-encoded-transform/commit/5e8290092811c1befde27fa1b90cb81a4fbf4eff.

`[=AbortController/signal=]` was [recently exported](https://github.com/whatwg/dom/commit/86022424b865fa50ade8a90825b47a0012a16ae0) so the signal can be accessed in other specs, since IDL getters/dot notation shouldn't be used.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shaseley/webrtc-encoded-transform/pull/190.html" title="Last updated on Jun 22, 2023, 10:09 PM UTC (f3bd156)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/190/49f981b...shaseley:f3bd156.html" title="Last updated on Jun 22, 2023, 10:09 PM UTC (f3bd156)">Diff</a>