### PR TITLE
Use Infinity as highWaterMark value instead of having the sizeAlgorithm returning zero

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -89,8 +89,8 @@ At construction of each {{RTCRtpSender}} or {{RTCRtpReceiver}}, run the followin
 4. <a dfn for="ReadableStream">Set up</a> [=this=].`[[readable]]`. [=this=].`[[readable]]` is provided frames using the [$readEncodedData$] algorithm given |this| as parameter.
 5. Set [=this=].`[[readable]]`.`[[owner]]` to |this|.
 6. Initialize [=this=].`[[writable]]` to a new {{WritableStream}}.
-7. <a dfn for="WritableStream">Set up</a> [=this=].`[[writable]]` with its [=WritableStream/set up/writeAlgorithm=] set to [$writeEncodedData$] given |this| as parameter and its [=WritableStream/set up/sizeAlgorithm=] to an algorithm that returns <code>0</code>.
-    <p class="note">Chunk size is set to 0 to explictly disable streams backpressure on the write side.</p>
+7. <a dfn for="WritableStream">Set up</a> [=this=].`[[writable]]` with its [=WritableStream/set up/writeAlgorithm=] set to [$writeEncodedData$] given |this| as parameter and its [=WritableStream/set up/highWaterMark=] set to <code>Infinity</code>.
+    <p class="note">highWaterMark is set to Infinity to explicitly disable backpressure. The goal is to limit buffering as much as possible.</p>
 8. Set [=this=].`[[writable]]`.`[[owner]]` to |this|.
 9. Initialize [=this=].`[[pipeToController]]` to null.
 1. Initialize [=this=].`[[lastReceivedFrameCounter]]` to <code>0</code>.

--- a/index.bs
+++ b/index.bs
@@ -105,7 +105,7 @@ At construction of each {{RTCRtpSender}} or {{RTCRtpReceiver}}, run the followin
 Streams backpressure can optimize throughput while limiting processing and memory consumption by pausing data production as early as possible in a data pipeline.
 This proves useful in contexts where reliability is essential and latency is less of a concern.
 On the other hand, WebRTC media pipelines favour low latency over reliability, for instance by allowing to drop frames at various places and by using recovery mechanisms.
-Buffering within WebRTC encoded transform would add latency without allowing web applications to adapt much.
+Buffering within a transform would add latency without allowing web applications to adapt much.
 The User Agent is responsible to do these adaptations, especially since it controls both ends of the transform.
 For those reasons, streams backpressure is disabled in WebRTC encoded transforms.
 </p>

--- a/index.bs
+++ b/index.bs
@@ -104,7 +104,7 @@ At construction of each {{RTCRtpSender}} or {{RTCRtpReceiver}}, run the followin
 <p class=note>
 Streams backpressure can optimize throughput while limiting processing and memory consumption by pausing data production as early as possible in a data pipeline.
 This proves useful in contexts where reliability is essential and latency is less of a concern.
-On the other hand, WebRTC media pipelines favour latency over reliability, for instance by allowing to drop frames at various places and by using recovery mechanisms.
+On the other hand, WebRTC media pipelines favour low latency over reliability, for instance by allowing to drop frames at various places and by using recovery mechanisms.
 Buffering within WebRTC encoded transform would add latency without allowing web applications to adapt much.
 The User Agent is responsible to do these adaptations, especially since it controls both ends of the transform.
 For those reasons, streams backpressure is disabled in WebRTC encoded transforms.

--- a/index.bs
+++ b/index.bs
@@ -90,7 +90,7 @@ At construction of each {{RTCRtpSender}} or {{RTCRtpReceiver}}, run the followin
 5. Set [=this=].`[[readable]]`.`[[owner]]` to |this|.
 6. Initialize [=this=].`[[writable]]` to a new {{WritableStream}}.
 7. <a dfn for="WritableStream">Set up</a> [=this=].`[[writable]]` with its [=WritableStream/set up/writeAlgorithm=] set to [$writeEncodedData$] given |this| as parameter and its [=WritableStream/set up/highWaterMark=] set to <code>Infinity</code>.
-    <p class="note">highWaterMark is set to Infinity to explicitly disable backpressure. The goal is to limit buffering as much as possible.</p>
+    <p class="note">highWaterMark is set to Infinity to explicitly disable backpressure.</p>
 8. Set [=this=].`[[writable]]`.`[[owner]]` to |this|.
 9. Initialize [=this=].`[[pipeToController]]` to null.
 1. Initialize [=this=].`[[lastReceivedFrameCounter]]` to <code>0</code>.
@@ -100,6 +100,15 @@ At construction of each {{RTCRtpSender}} or {{RTCRtpReceiver}}, run the followin
     2. Set [=this=].`[[pipeToController]]` to a new {{AbortController}}.
     <!-- FIXME: Use pipeTo algorithm when available. -->
     3. Call <a href="https://streams.spec.whatwg.org/#readable-stream-pipe-to">pipeTo</a> with [=this=].`[[readable]]`, [=this=].`[[writable]]`, preventClose equal to true, preventAbort equal to true, preventCancel equal to true and [=this=].`[[pipeToController]]`.signal.
+
+<p class=note>
+Streams backpressure can optimize throughput while limiting processing and memory consumption by pausing data production as early as possible in a data pipeline.
+This proves useful in contexts where reliability is essential and latency is less of a concern.
+On the other hand, WebRTC media pipelines favour latency over reliability, for instance by allowing to drop frames at various places and by using recovery mechanisms.
+Buffering within WebRTC encoded transform would add latency without allowing web applications to adapt much.
+The User Agent is responsible to do these adaptations, especially since it controls both ends of the transform.
+For those reasons, streams backpressure is disabled in WebRTC encoded transforms.
+</p>
 
 ### Stream processing ### {#stream-processing}
 

--- a/index.bs
+++ b/index.bs
@@ -106,7 +106,7 @@ Streams backpressure can optimize throughput while limiting processing and memor
 This proves useful in contexts where reliability is essential and latency is less of a concern.
 On the other hand, WebRTC media pipelines favour low latency over reliability, for instance by allowing to drop frames at various places and by using recovery mechanisms.
 Buffering within a transform would add latency without allowing web applications to adapt much.
-The User Agent is responsible to do these adaptations, especially since it controls both ends of the transform.
+The User Agent is responsible for doing these adaptations, especially since it controls both ends of the transform.
 For those reasons, streams backpressure is disabled in WebRTC encoded transforms.
 </p>
 


### PR DESCRIPTION
This makes it clearer backpressure is disabled.
Mention reducing buffering as the reason behind this choice.

Fixes https://github.com/w3c/webrtc-encoded-transform/issues/188.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-insertable-streams/pull/195.html" title="Last updated on Jul 27, 2023, 2:56 PM UTC (de1a683)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/195/4bd0792...youennf:de1a683.html" title="Last updated on Jul 27, 2023, 2:56 PM UTC (de1a683)">Diff</a>