### PR TITLE
IDL changes for setMetadata for 3.2.2 webrtc nv use case

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -330,8 +330,8 @@ enum RTCEncodedVideoFrameType {
 ## <dfn dictionary>RTCEncodedVideoFrameMetadata</dfn> dictionary ## {#RTCEncodedVideoFrameMetadata}
 <pre class="idl">
 dictionary RTCEncodedVideoFrameMetadata {
-    unsigned long long frameId;
-    sequence&lt;unsigned long long&gt; dependencies;
+    required unsigned long long frameId;
+    required sequence&lt;unsigned long long&gt; dependencies;
     unsigned short width;
     unsigned short height;
     unsigned long spatialIndex;
@@ -340,7 +340,7 @@ dictionary RTCEncodedVideoFrameMetadata {
     octet payloadType;
     sequence&lt;unsigned long&gt; contributingSources;
     long long timestamp;    // microseconds
-    unsigned long rtpTimestamp;
+    required unsigned long rtpTimestamp;
 };
 </pre>
 
@@ -483,7 +483,7 @@ dictionary RTCEncodedAudioFrameMetadata {
     octet payloadType;
     sequence&lt;unsigned long&gt; contributingSources;
     short sequenceNumber;
-    unsigned long rtpTimestamp;
+    required unsigned long rtpTimestamp;
 };
 </pre>
 ### Members ### {#RTCEncodedAudioFrameMetadata-members}

--- a/index.bs
+++ b/index.bs
@@ -121,7 +121,7 @@ The <dfn abstract-op>readEncodedData</dfn> algorithm is given a |rtcObject| as p
 1. [=ReadableStream/Enqueue=] |frame| in |rtcObject|.`[[readable]]`.
 
 The <dfn abstract-op>writeEncodedData</dfn> algorithm is given a |rtcObject| as parameter and a |frame| as input. It is defined by running the following steps:
-1. If |frame|.`[[owner]]` is not equal to |rtcObject|, abort these steps and return [=a promise resolved with=] undefined. A processor cannot create frames, or move frames between streams.
+1. If |frame|.`[[owner]]` is not equal to |rtcObject|, skip to step 4. In this case, either frames were created or moved between streams.
 1. If |frame|.`[[counter]]` is equal or smaller than |rtcObject|.`[[lastReceivedFrameCounter]]`, abort these steps and return [=a promise resolved with=] undefined. A processor cannot reorder frames, although it may delay them or drop them.
 1. Set |rtcObject|.`[[lastReceivedFrameCounter]]` to |frame|`[[counter]]`.
 1. Let |data| be |frame|.`[[data]]`.
@@ -448,7 +448,9 @@ interface RTCEncodedVideoFrame {
     </dt>
     <dd>
         <p>
-            Sets a new metadata that would be associated with the frame.
+            Sets a new metadata that would be associated with the frame. Only allowed to change the fields
+	    frameId, dependencies and rtpTimetsamp in the RTCEncodedVideoFrameMetadata. All other changes
+	    are not allowed and should return an error.
         </p>
     </dd>
 </dl>

--- a/index.bs
+++ b/index.bs
@@ -462,6 +462,7 @@ dictionary RTCEncodedAudioFrameMetadata {
     octet payloadType;
     sequence&lt;unsigned long&gt; contributingSources;
     short sequenceNumber;
+    attribute unsigned long rtpTimestamp;
 };
 </pre>
 ### Members ### {#RTCEncodedAudioFrameMetadata-members}
@@ -505,22 +506,8 @@ dictionary RTCEncodedAudioFrameMetadata {
             Comparing two sequence numbers requires serial number arithmetic described in [[RFC1982]].
         </p>
     </dd>
-</dl>
-
-## <dfn interface>RTCEncodedAudioFrame</dfn> interface ## {#RTCEncodedAudioFrame-interface}
-<pre class="idl">
-[Exposed=(Window,DedicatedWorker)]
-interface RTCEncodedAudioFrame {
-    attribute unsigned long timestamp;
-    attribute ArrayBuffer data;
-    RTCEncodedAudioFrameMetadata getMetadata();
-};
-</pre>
-
-### Members ### {#RTCEncodedAudioFrame-members}
-<dl dfn-for="RTCEncodedAudioFrame" class="dictionary-members">
     <dt>
-        <dfn attribute>timestamp</dfn> of type <span class="idlMemberType">unsigned long</span>
+        <dfn attribute>rtpTimestamp</dfn> of type <span class="idlMemberType">unsigned long</span>
     </dt>
     <dd>
         <p>
@@ -528,6 +515,20 @@ interface RTCEncodedAudioFrame {
             that reflects the sampling instant of the first octet in the RTP data packet.
         </p>
     </dd>
+</dl>
+
+## <dfn interface>RTCEncodedAudioFrame</dfn> interface ## {#RTCEncodedAudioFrame-interface}
+<pre class="idl">
+[Exposed=(Window,DedicatedWorker)]
+interface RTCEncodedAudioFrame {
+    attribute ArrayBuffer data;
+    RTCEncodedAudioFrameMetadata getMetadata();
+    void setMetadata(RTCEncodedAudioFrameMetadata metadata);
+};
+</pre>
+
+### Members ### {#RTCEncodedAudioFrame-members}
+<dl dfn-for="RTCEncodedAudioFrame" class="dictionary-members">
     <dt>
         <dfn attribute>data</dfn> of type <span class="idlMemberType">ArrayBuffer</span>
     </dt>
@@ -550,6 +551,16 @@ interface RTCEncodedAudioFrame {
     </dd>
 </dl>
 
+    <dt>
+        <dfn for="RTCEncodedAudioFrame" method>setMetadata()</dfn>
+    </dt>
+    <dd>
+        <p>
+            Sets a new metadata that would be associated with the frame. Only allowed to change
+	    the rtpTimetsamp field in the RTCEncodedAudioFrameMetadata. All other changes are
+	    not allowed and should return an error.
+        </p>
+    </dd>
 
 // New interfaces to expose JavaScript-based transforms.
 ##Interfaces

--- a/index.bs
+++ b/index.bs
@@ -406,7 +406,7 @@ interface RTCEncodedVideoFrame {
     readonly attribute RTCEncodedVideoFrameType type;
     attribute ArrayBuffer data;
     RTCEncodedVideoFrameMetadata getMetadata();
-    undefined setMetadata(RTCEncodedVideoFrameMetadata metadata);
+    undefined setMetadata(required RTCEncodedVideoFrameMetadata metadata);
 };
 </pre>
 
@@ -544,7 +544,7 @@ dictionary RTCEncodedAudioFrameMetadata {
 interface RTCEncodedAudioFrame {
     attribute ArrayBuffer data;
     RTCEncodedAudioFrameMetadata getMetadata();
-    undefined setMetadata(RTCEncodedAudioFrameMetadata metadata);
+    undefined setMetadata(required RTCEncodedAudioFrameMetadata metadata);
 };
 </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -376,7 +376,7 @@ dictionary RTCEncodedVideoFrameMetadata {
     </dd>
 
     <dt>
-        <dfn attribute>rtpTimestamp</dfn> of type <span class="idlMemberType">unsigned long</span>
+        <dfn dict-member>rtpTimestamp</dfn> of type <span class="idlMemberType">unsigned long</span>
     </dt>
     <dd>
         <p>
@@ -386,7 +386,7 @@ dictionary RTCEncodedVideoFrameMetadata {
     </dd>
 
     <dt>
-        <dfn>presentationTimestamp</dfn> of type <span class=
+        <dfn dict-member>presentationTimestamp</dfn> of type <span class=
             "idlMemberType">long long</span>
     </dt>
     <dd>

--- a/index.bs
+++ b/index.bs
@@ -339,7 +339,8 @@ dictionary RTCEncodedVideoFrameMetadata {
     unsigned long synchronizationSource;
     octet payloadType;
     sequence&lt;unsigned long&gt; contributingSources;
-    long long timestamp;    // microseconds
+    unsigned long rtpTimestamp;
+    long long presentationTimestamp;    // microseconds
 };
 </pre>
 
@@ -373,8 +374,19 @@ dictionary RTCEncodedVideoFrameMetadata {
             The list of contribution sources (csrc list) as defined in [[RFC3550]].
         </p>
     </dd>
+
     <dt>
-        <dfn>timestamp</dfn> of type <span class=
+        <dfn attribute>rtpTimestamp</dfn> of type <span class="idlMemberType">unsigned long</span>
+    </dt>
+    <dd>
+        <p>
+            The RTP timestamp identifier is an unsigned integer value per [[RFC3550]]
+            that reflects the sampling instant of the first octet in the RTP data packet.
+        </p>
+    </dd>
+
+    <dt>
+        <dfn>presentationTimestamp</dfn> of type <span class=
             "idlMemberType">long long</span>
     </dt>
     <dd>
@@ -393,9 +405,9 @@ dictionary RTCEncodedVideoFrameMetadata {
 [Exposed=(Window,DedicatedWorker)]
 interface RTCEncodedVideoFrame {
     readonly attribute RTCEncodedVideoFrameType type;
-    readonly attribute unsigned long timestamp;
     attribute ArrayBuffer data;
     RTCEncodedVideoFrameMetadata getMetadata();
+    void setMetadata(RTCEncodedVideoFrameMetadata metadata);
 };
 </pre>
 
@@ -411,15 +423,6 @@ interface RTCEncodedVideoFrame {
         </p>
     </dd>
 
-    <dt>
-        <dfn attribute>timestamp</dfn> of type <span class="idlMemberType">unsigned long</span>
-    </dt>
-    <dd>
-        <p>
-            The RTP timestamp identifier is an unsigned integer value per [[RFC3550]]
-            that reflects the sampling instant of the first octet in the RTP data packet.
-        </p>
-    </dd>
     <dt>
         <dfn attribute>data</dfn> of type <span class="idlMemberType">ArrayBuffer</span>
     </dt>
@@ -438,6 +441,14 @@ interface RTCEncodedVideoFrame {
     <dd>
         <p>
             Returns the metadata associated with the frame.
+        </p>
+    </dd>
+    <dt>
+        <dfn for="RTCEncodedVideoFrame" method>setMetadata()</dfn>
+    </dt>
+    <dd>
+        <p>
+            Sets a new metadata that would be associated with the frame.
         </p>
     </dd>
 </dl>
@@ -498,7 +509,7 @@ dictionary RTCEncodedAudioFrameMetadata {
 <pre class="idl">
 [Exposed=(Window,DedicatedWorker)]
 interface RTCEncodedAudioFrame {
-    readonly attribute unsigned long timestamp;
+    attribute unsigned long timestamp;
     attribute ArrayBuffer data;
     RTCEncodedAudioFrameMetadata getMetadata();
 };

--- a/index.bs
+++ b/index.bs
@@ -406,7 +406,7 @@ interface RTCEncodedVideoFrame {
     readonly attribute RTCEncodedVideoFrameType type;
     attribute ArrayBuffer data;
     RTCEncodedVideoFrameMetadata getMetadata();
-    void setMetadata(RTCEncodedVideoFrameMetadata metadata);
+    undefined setMetadata(RTCEncodedVideoFrameMetadata metadata);
 };
 </pre>
 
@@ -544,7 +544,7 @@ dictionary RTCEncodedAudioFrameMetadata {
 interface RTCEncodedAudioFrame {
     attribute ArrayBuffer data;
     RTCEncodedAudioFrameMetadata getMetadata();
-    void setMetadata(RTCEncodedAudioFrameMetadata metadata);
+    undefined setMetadata(RTCEncodedAudioFrameMetadata metadata);
 };
 </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -330,8 +330,8 @@ enum RTCEncodedVideoFrameType {
 ## <dfn dictionary>RTCEncodedVideoFrameMetadata</dfn> dictionary ## {#RTCEncodedVideoFrameMetadata}
 <pre class="idl">
 dictionary RTCEncodedVideoFrameMetadata {
-    required unsigned long long frameId;
-    required sequence&lt;unsigned long long&gt; dependencies;
+    unsigned long long frameId;
+    sequence&lt;unsigned long long&gt; dependencies;
     unsigned short width;
     unsigned short height;
     unsigned long spatialIndex;
@@ -340,7 +340,7 @@ dictionary RTCEncodedVideoFrameMetadata {
     octet payloadType;
     sequence&lt;unsigned long&gt; contributingSources;
     long long timestamp;    // microseconds
-    required unsigned long rtpTimestamp;
+    unsigned long rtpTimestamp;
 };
 </pre>
 
@@ -406,7 +406,7 @@ interface RTCEncodedVideoFrame {
     readonly attribute RTCEncodedVideoFrameType type;
     attribute ArrayBuffer data;
     RTCEncodedVideoFrameMetadata getMetadata();
-    undefined setMetadata(required RTCEncodedVideoFrameMetadata metadata);
+    undefined setMetadata(optional RTCEncodedVideoFrameMetadata metadata = {});
 };
 </pre>
 
@@ -483,7 +483,7 @@ dictionary RTCEncodedAudioFrameMetadata {
     octet payloadType;
     sequence&lt;unsigned long&gt; contributingSources;
     short sequenceNumber;
-    required unsigned long rtpTimestamp;
+    unsigned long rtpTimestamp;
 };
 </pre>
 ### Members ### {#RTCEncodedAudioFrameMetadata-members}
@@ -544,7 +544,7 @@ dictionary RTCEncodedAudioFrameMetadata {
 interface RTCEncodedAudioFrame {
     attribute ArrayBuffer data;
     RTCEncodedAudioFrameMetadata getMetadata();
-    undefined setMetadata(required RTCEncodedAudioFrameMetadata metadata);
+    undefined setMetadata(optional RTCEncodedAudioFrameMetadata metadata = {});
 };
 </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -121,7 +121,7 @@ The <dfn abstract-op>readEncodedData</dfn> algorithm is given a |rtcObject| as p
 1. [=ReadableStream/Enqueue=] |frame| in |rtcObject|.`[[readable]]`.
 
 The <dfn abstract-op>writeEncodedData</dfn> algorithm is given a |rtcObject| as parameter and a |frame| as input. It is defined by running the following steps:
-1. If |frame|.`[[owner]]` is not equal to |rtcObject|, skip to step 4. In this case, either frames were created or moved between streams.
+1. If |frame|.`[[owner]]` is not equal to |rtcObject|, abort these steps and return [=a promise resolved with=] undefined. A processor cannot create frames, or move frames between streams.
 1. If |frame|.`[[counter]]` is equal or smaller than |rtcObject|.`[[lastReceivedFrameCounter]]`, abort these steps and return [=a promise resolved with=] undefined. A processor cannot reorder frames, although it may delay them or drop them.
 1. Set |rtcObject|.`[[lastReceivedFrameCounter]]` to |frame|`[[counter]]`.
 1. Let |data| be |frame|.`[[data]]`.

--- a/index.bs
+++ b/index.bs
@@ -374,7 +374,6 @@ dictionary RTCEncodedVideoFrameMetadata {
             The list of contribution sources (csrc list) as defined in [[RFC3550]].
         </p>
     </dd>
-
     <dt>
         <dfn dict-member>rtpTimestamp</dfn> of type <span class="idlMemberType">unsigned long</span>
     </dt>
@@ -384,7 +383,6 @@ dictionary RTCEncodedVideoFrameMetadata {
             that reflects the sampling instant of the first octet in the RTP data packet.
         </p>
     </dd>
-
     <dt>
         <dfn dict-member>presentationTimestamp</dfn> of type <span class=
             "idlMemberType">long long</span>
@@ -462,7 +460,7 @@ dictionary RTCEncodedAudioFrameMetadata {
     octet payloadType;
     sequence&lt;unsigned long&gt; contributingSources;
     short sequenceNumber;
-    attribute unsigned long rtpTimestamp;
+    unsigned long rtpTimestamp;
 };
 </pre>
 ### Members ### {#RTCEncodedAudioFrameMetadata-members}
@@ -507,7 +505,7 @@ dictionary RTCEncodedAudioFrameMetadata {
         </p>
     </dd>
     <dt>
-        <dfn attribute>rtpTimestamp</dfn> of type <span class="idlMemberType">unsigned long</span>
+        <dfn dict-member>rtpTimestamp</dfn> of type <span class="idlMemberType">unsigned long</span>
     </dt>
     <dd>
         <p>
@@ -549,8 +547,6 @@ interface RTCEncodedAudioFrame {
             Returns the metadata associated with the frame.
         </p>
     </dd>
-</dl>
-
     <dt>
         <dfn for="RTCEncodedAudioFrame" method>setMetadata()</dfn>
     </dt>
@@ -561,6 +557,8 @@ interface RTCEncodedAudioFrame {
 	    not allowed and should return an error.
         </p>
     </dd>
+</dl>
+
 
 // New interfaces to expose JavaScript-based transforms.
 ##Interfaces


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/palak8669/webrtc-encoded-transform/pull/202.html" title="Last updated on Oct 12, 2023, 8:09 AM UTC (0a86a80)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/202/7721c15...palak8669:0a86a80.html" title="Last updated on Oct 12, 2023, 8:09 AM UTC (0a86a80)">Diff</a>