### PR TITLE
Remove (de)serialization of no longer existent RTCEncodedVideoFrame.timestamp

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -375,7 +375,7 @@ dictionary RTCEncodedVideoFrameMetadata {
         </p>
     </dd>
     <dt>
-        <dfn>timestamp</dfn> <span class=
+        <dfn dict-member>timestamp</dfn> <span class=
             "idlMemberType">long long</span>
     </dt>
     <dd>

--- a/index.bs
+++ b/index.bs
@@ -567,13 +567,11 @@ interface RTCEncodedAudioFrame {
 Their [=serialization steps=], given |value|, |serialized|, and |forStorage|, are:
 
 1. If |forStorage| is true, then throw a {{DataCloneError}}.
-1. Set |serialized|.`[[timestamp]]` to the value of |value|.{{RTCEncodedAudioFrame/timestamp}}
 1. Set |serialized|.`[[metadata]]` to an internal representation of |value|'s metadata.
 1. Set |serialized|.`[[data]]` to |value|.`[[data]]`
 
 Their [=deserialization steps=], given |serialized|, |value| and |realm|, are:
 
-1. Set |value|.{{RTCEncodedAudioFrame/timestamp}} to |serialized|.`[[timestamp]]`
 1. Set |value|'s metadata to the platform object representation of |serialized|.`[[metadata]]`
 1. Set |value|.`[[data]]` to |serialized|.`[[data]]`.
 

--- a/index.bs
+++ b/index.bs
@@ -449,14 +449,12 @@ Their [=serialization steps=], given |value|, |serialized|, and |forStorage|, ar
 
 1. If |forStorage| is true, then throw a {{DataCloneError}}.
 1. Set |serialized|.`[[type]]` to the value of |value|.{{RTCEncodedVideoFrame/type}}
-1. Set |serialized|.`[[timestamp]]` to the value of |value|.{{RTCEncodedVideoFrame/timestamp}}
 1. Set |serialized|.`[[metadata]]` to an internal representation of |value|'s metadata.
 1. Set |serialized|.`[[data]]` to |value|.`[[data]]`
 
 Their [=deserialization steps=], given |serialized|, |value| and |realm|, are:
 
 1. Set |value|.{{RTCEncodedVideoFrame/type}} to |serialized|.`[[type]]`
-1. Set |value|.{{RTCEncodedVideoFrame/timestamp}} to |serialized|.`[[timestamp]]`
 1. Set |value|'s metadata to the platform object representation of |serialized|.`[[metadata]]`
 1. Set |value|.`[[data]]` to |serialized|.`[[data]]`.
 


### PR DESCRIPTION
follow up to #204
fix CI error noted in https://github.com/w3c/webrtc-encoded-transform/pull/140#issuecomment-1749177413


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/pull/208.html" title="Last updated on Oct 9, 2023, 9:14 AM UTC (3041a21)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/208/e258de1...3041a21.html" title="Last updated on Oct 9, 2023, 9:14 AM UTC (3041a21)">Diff</a>