### PR TITLE
Describe "data" attribute

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -460,7 +460,14 @@ interface RTCEncodedVideoFrame {
             The encoded frame data. The format of the data depends on the video codec that is
             used to encode/decode the frame which can be determined by looking at the
             {{RTCEncodedVideoFrameMetadata/mimeType}}.
-            The following table defines this for a number of codecs.
+            For <a href="https://w3c.github.io/webrtc-svc/">SVC</a>, each spatial layer
+            is transformed separately.
+            <p class="note">
+              Since packetizers may drop certain elements, e.g. AV1 temporal delimiter OBUs,
+              the input to an receive-side transform may be different from the output of
+              a send-side transform.
+            </p>
+            The following table gives a number of examples:
         </p>
         <table class="simple">
             <thead>
@@ -486,8 +493,8 @@ interface RTCEncodedVideoFrame {
                         video/VP9
                     </td>
                     <td>
-                        The data is a frame as described in Section 6 of [[VP9]]. The
-                        <a href="https://datatracker.ietf.org/doc/html/draft-ietf-payload-vp9#section-4.2">
+                        The data is a frame as described in Section 6 of [[VP9]].
+                        The <a href="https://datatracker.ietf.org/doc/html/draft-ietf-payload-vp9#section-4.2">
                         VP9 payload descriptor</a> is not accessible.
                     </td>
                 </tr>
@@ -643,7 +650,7 @@ interface RTCEncodedAudioFrame {
             The encoded frame data. The format of the data depends on the audio codec that is
             used to encode/decode the frame which can be determined by looking at the
             {{RTCEncodedAudioFrameMetadata/mimeType}}.
-            The following table defines this for a number of codecs.
+            The following table gives a number of examples:
         </p>
         <table class="simple">
             <thead>

--- a/index.bs
+++ b/index.bs
@@ -35,9 +35,9 @@ spec:webidl; type:dfn; text:resolve
     "title": "VP9 Bitstream & Decoding Process Specification",
     "publisher": "The WebM Project"
    },
-   "ITU-T-REC-H.265": {
-    "href": "https://www.itu.int/rec/T-REC-H.265",
-    "title": "H.265 : High efficiency video coding",
+   "ITU-T-REC-H.264": {
+    "href": "https://www.itu.int/rec/T-REC-H.264",
+    "title": "H.264 : Advanced video coding for generic audiovisual services",
     "publisher": "ITU"
    },
    "ITU-G.711": {
@@ -47,7 +47,7 @@ spec:webidl; type:dfn; text:resolve
    },
    "ITU-G.722": {
     "href": "https://www.itu.int/rec/T-REC-G.722/",
-    "title": "G.722: 7 kHz audio-coding within 64 kbit/s",
+    "title": "G.722 : 7 kHz audio-coding within 64 kbit/s",
     "publisher": "ITU"
    }
 }
@@ -496,7 +496,7 @@ interface RTCEncodedVideoFrame {
                     </td>
                     <td>
                         The data is a series of NAL units in Annex B format,
-                        as defined in [[ITU-T-REC-H.265]] Annex B.
+                        as defined in [[ITU-T-REC-H.264]] Annex B.
                     </td>
                 </tr>
                 <tr>

--- a/index.bs
+++ b/index.bs
@@ -155,7 +155,7 @@ The <dfn abstract-op>writeEncodedData</dfn> algorithm is given a |rtcObject| as 
 
 On sender side, as part of [$readEncodedData$], frames produced by |rtcObject|'s encoder MUST be enqueued in |rtcObject|.`[[readable]]` in the encoder's output order.
 As [$writeEncodedData$] ensures that the transform cannot reorder frames, the encoder's output order is also the order followed by packetizers to generate RTP packets and assign RTP packet sequence numbers.
-The packetizer may expect the transformed data to still conform to the original format, e.g. a series of NAL units separated by Annex B start codecs.
+The packetizer may expect the transformed data to still conform to the original format, e.g. a series of NAL units separated by Annex B start codes.
 
 On receiver side, as part of [$readEncodedData$], frames produced by |rtcObject|'s packetizer MUST be enqueued in |rtcObject|.`[[readable]]` in the same encoder's output order.
 To ensure the order is respected, the depacketizer will typically use RTP packet sequence numbers to reorder RTP packets as needed before enqueuing frames in |rtcObject|.`[[readable]]`.

--- a/index.bs
+++ b/index.bs
@@ -155,6 +155,7 @@ The <dfn abstract-op>writeEncodedData</dfn> algorithm is given a |rtcObject| as 
 
 On sender side, as part of [$readEncodedData$], frames produced by |rtcObject|'s encoder MUST be enqueued in |rtcObject|.`[[readable]]` in the encoder's output order.
 As [$writeEncodedData$] ensures that the transform cannot reorder frames, the encoder's output order is also the order followed by packetizers to generate RTP packets and assign RTP packet sequence numbers.
+The packetizer may expect the transformed data to still conform to the original format, e.g. a series of NAL units separated by Annex B start codecs.
 
 On receiver side, as part of [$readEncodedData$], frames produced by |rtcObject|'s packetizer MUST be enqueued in |rtcObject|.`[[readable]]` in the same encoder's output order.
 To ensure the order is respected, the depacketizer will typically use RTP packet sequence numbers to reorder RTP packets as needed before enqueuing frames in |rtcObject|.`[[readable]]`.
@@ -457,9 +458,9 @@ interface RTCEncodedVideoFrame {
     <dd>
         <p>
             The encoded frame data. The format of the data depends on the video codec that is
-            used to encode the frame which can be determined by looking at the
-            {{RTCEncodedVideoFrameMetadata/mimeType}}. The following table defines this for
-            a number of codecs.
+            used to encode/decode the frame which can be determined by looking at the
+            {{RTCEncodedVideoFrameMetadata/mimeType}}.
+            The following table defines this for a number of codecs.
         </p>
         <table class="simple">
             <thead>
@@ -640,9 +641,9 @@ interface RTCEncodedAudioFrame {
     <dd>
         <p>
             The encoded frame data. The format of the data depends on the audio codec that is
-            used to encode the frame which can be determined by looking at the
-            {{RTCEncodedAudioFrameMetadata/mimeType}}. The following table defines this for
-            a number of codecs.
+            used to encode/decode the frame which can be determined by looking at the
+            {{RTCEncodedAudioFrameMetadata/mimeType}}.
+            The following table defines this for a number of codecs.
         </p>
         <table class="simple">
             <thead>
@@ -657,8 +658,8 @@ interface RTCEncodedAudioFrame {
                     </td>
                     <td>
                         The data is Opus packets, as described in
-                        <a href="https://datatracker.ietf.org/doc/html/rfc6716#section-3">section 3</a>
-                        of [[RFC6716]].
+                        <a href="https://datatracker.ietf.org/doc/html/rfc6716#section-3">
+                        section 3</a> of [[RFC6716]].
                     </td>
                 </tr>
                 <tr>
@@ -689,10 +690,21 @@ interface RTCEncodedAudioFrame {
                 </tr>
                 <tr>
                     <td>
+                        audio/RED
+                    </td>
+                    <td>
+                        The data is Redundant Audio Data as described in
+                        <a href="https://www.rfc-editor.org/rfc/rfc2198#section-3">
+                        section 3</a> of [[RFC2198]].
+                    </td>
+                </tr>
+                <tr>
+                    <td>
                         audio/CN
                     </td>
                     <td>
-                        The data is Comfort Noise as described in <a href="https://www.rfc-editor.org/rfc/rfc3389#section-3">
+                        The data is Comfort Noise as described in
+                        <a href="https://www.rfc-editor.org/rfc/rfc3389#section-3">
                         section 3</a> of [[RFC3389]].
                     </td>
                 </tr>

--- a/index.bs
+++ b/index.bs
@@ -28,6 +28,27 @@ spec:webidl; type:dfn; text:resolve
      "href":
      "https://www.ietf.org/archive/id/draft-ietf-sframe-enc-00.html",
      "title": "Secure Frame (SFrame)"
+   },
+   "VP9": {
+    "href":
+    "https://storage.googleapis.com/downloads.webmproject.org/docs/vp9/vp9-bitstream-specification-v0.6-20160331-draft.pdf",
+    "title": "VP9 Bitstream & Decoding Process Specification",
+    "publisher": "The WebM Project"
+   },
+   "ITU-T-REC-H.265": {
+    "href": "https://www.itu.int/rec/T-REC-H.265",
+    "title": "H.265 : High efficiency video coding",
+    "publisher": "ITU"
+   },
+   "ITU-G.711": {
+    "href": "https://www.itu.int/rec/T-REC-G.711/",
+    "title": "G.711 : Pulse code modulation (PCM) of voice frequencies",
+    "publisher": "ITU"
+   },
+   "ITU-G.722": {
+    "href": "https://www.itu.int/rec/T-REC-G.722/",
+    "title": "G.722: 7 kHz audio-coding within 64 kbit/s",
+    "publisher": "ITU"
    }
 }
 </pre>
@@ -435,8 +456,63 @@ interface RTCEncodedVideoFrame {
     </dt>
     <dd>
         <p>
-            The encoded frame data.
+            The encoded frame data. The format of the data depends on the video codec that is
+            used to encode the frame which can be determined by looking at the
+            {{RTCEncodedVideoFrameMetadata/mimeType}}. The following table defines this for
+            a number of codecs.
         </p>
+        <table class="simple">
+            <thead>
+                <tr>
+                    <th>mimeType</th><th>Data format</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>
+                        video/VP8
+                    </td>
+                    <td>
+                        The data starts with the "uncompressed data chunk" defined in
+                        <a href="https://datatracker.ietf.org/doc/html/rfc6386#section-9.1">
+                        section 9.1</a> of [[RFC6386]] and is followed by the rest of the
+                        frame data. The <a href="https://www.rfc-editor.org/rfc/rfc7741#section-4.1">
+                        VP8 payload descriptor</a> is not accessible.
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        video/VP9
+                    </td>
+                    <td>
+                        The data is a frame as described in Section 6 of [[VP9]]. The
+                        <a href="https://datatracker.ietf.org/doc/html/draft-ietf-payload-vp9#section-4.2">
+                        VP9 payload descriptor</a> is not accessible.
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        video/H264
+                    </td>
+                    <td>
+                        The data is a series of NAL units in Annex B format,
+                        as defined in [[ITU-T-REC-H.265]] Annex B.
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        video/AV1
+                    </td>
+                    <td>
+                        The data is a series of OBUs compliant to the
+                        <a href="https://aomediacodec.github.io/av1-spec/#low-overhead-bitstream-format">
+                        low-overhead bitstream format</a> as described in Section 5 of [[AV1]].
+                        The <a href="https://aomediacodec.github.io/av1-rtp-spec/#41-rtp-header-usage">
+                        AV1 aggregation header</a> is not accessible.
+                    </td>
+                </tr>
+            </tbody>
+        </table>
     </dd>
 </dl>
 
@@ -563,8 +639,65 @@ interface RTCEncodedAudioFrame {
     </dt>
     <dd>
         <p>
-            The encoded frame data.
+            The encoded frame data. The format of the data depends on the audio codec that is
+            used to encode the frame which can be determined by looking at the
+            {{RTCEncodedAudioFrameMetadata/mimeType}}. The following table defines this for
+            a number of codecs.
         </p>
+        <table class="simple">
+            <thead>
+                <tr>
+                    <th>mimeType</th><th>Data format</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>
+                        audio/opus
+                    </td>
+                    <td>
+                        The data is Opus packets, as described in
+                        <a href="https://datatracker.ietf.org/doc/html/rfc6716#section-3">section 3</a>
+                        of [[RFC6716]].
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        audio/PCMU
+                    </td>
+                    <td>
+                        The data is a sequence of bytes of arbitrary length, where each byte is a u-law
+                        encoded PCM sample as defined by Table 2a and 2b in [[ITU-G.711]].
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        audio/PCMA
+                    </td>
+                    <td>
+                        The data is a sequence of bytes of arbitrary length, where each byte is
+                        an A-law encoded PCM sample as defined by Tables 1a and 1b in [[ITU-G.711]].
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        audio/G722
+                    </td>
+                    <td>
+                        The data is G.722 audio as described in [[ITU-G.722]].
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        audio/CN
+                    </td>
+                    <td>
+                        The data is Comfort Noise as described in <a href="https://www.rfc-editor.org/rfc/rfc3389#section-3">
+                        section 3</a> of [[RFC3389]].
+                    </td>
+                </tr>
+            </tbody>
+        </table>
     </dd>
 </dl>
 


### PR DESCRIPTION
With #140 merged it is now actually possible to describe what data is.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fippo/webrtc-media-streams/pull/212.html" title="Last updated on Nov 16, 2023, 4:36 PM UTC (0331aa9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/212/32f00c2...fippo:0331aa9.html" title="Last updated on Nov 16, 2023, 4:36 PM UTC (0331aa9)">Diff</a>