### PR TITLE
Add an API for a "keyframe has been requested" event

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -599,7 +599,7 @@ interface mixin RTCRtpScriptSource {
     readonly attribute ReadableStream readable;
     Promise&lt;unsigned long long&gt; generateKeyFrame(optional DOMString rid);
     Promise&lt;undefined&gt; sendKeyFrameRequest();
-    undefined bandwidthEstimate(BandwidthInfo info);
+    undefined sendBandwidthEstimate(BandwidthInfo info);
 };
 
 interface mixin RTCRtpScriptSink {
@@ -672,7 +672,7 @@ The <dfn method for="RTCRtpScriptSource">sendKeyFrameRequest()</dfn> method step
 1. Run the [$send request key frame algorithm$] with |promise| and |this|.`[[depacketizer]]`.
 1. Return |promise|.
 
-The <dfn method for="RTCRtpScriptSource">bandwidthEstimate()</dfn> method step are:
+The <dfn method for="RTCRtpScriptSource">sendBandwidthEstimate()</dfn> method step are:
 1. Configure the upstream source with the new bandwidth information.
 
 ## Attributes ## {#RTCRtpScriptTransformer-attributes}
@@ -698,9 +698,9 @@ The <dfn attribute for="RTCRtpScriptSink">onkeyframerequest</dfn> EventHandler h
 
 The following events fire on an RTCRtpScriptTransform:
 
-* bandwidthestimate of type {{BandwidthEstimateEvent}} - fired when the sink determines that the bandwidth estimate has changed significantly from what has been previously signalled. In the context of {{RTCRtpScriptTransform}}, if the event is not cancelled, the information will be passed to the source as if the bandwidthEstimate() function had been called.
+* bandwidthestimate of type {{BandwidthEstimateEvent}} - fired when the sink determines that the bandwidth estimate has changed significantly from what has been previously signalled. In the context of {{RTCRtpScriptTransform}}, if the event is not cancelled, the information will be passed to the source as if the sendBandwidthEstimate() function had been called.
 
-* keyframerequest of type {{KeyFrameRequestEvent}} - fired when the sink determines that a key frame has been requested. In the context of {{RTCRtpScriptTransform, if the event is not cancelled, the information will be passed to the source as if the generateKeyFrame() function had been called. <!-- NOTE IN DRAFT: generateKeyFrame() and requestKeyFrame() should merge -->
+* keyframerequest of type {{KeyFrameRequestEvent}} - fired when the sink determines that a key frame has been requested. In the context of {{RTCRtpScriptTransform}}, if the event is not cancelled, the information will be passed to the source as if the generateKeyFrame() function had been called. <!-- NOTE IN DRAFT: generateKeyFrame() and requestKeyFrame() should merge -->
 
 
 ## KeyFrame Algorithms ## {#KeyFrame-algorithms}

--- a/index.bs
+++ b/index.bs
@@ -590,14 +590,8 @@ partial interface DedicatedWorkerGlobalScope {
     attribute EventHandler onrtctransform;
 };
 
-interface mixin RTCRtpScriptSource {
-};
-
-interface mixin RTCRtpScriptSink {
-};
-
 [Exposed=DedicatedWorker]
-interface RTCRtpScriptTransformer {
+interface RTCRtpScriptTransformer : EventTarget {
     // Attributes and methods related to the transformer source
     readonly attribute ReadableStream readable;
     Promise&lt;unsigned long long&gt; generateKeyFrame(optional DOMString rid);
@@ -683,22 +677,21 @@ The <dfn attribute for="RTCRtpScriptTransform">onkeyframerequest</dfn> EventHand
 
 ## Events ## {#RTCRtpScriptTransformer-events}
 
-The following events fire on an {{RTCRtpScriptTransformer}}:
+The following event fires on an {{RTCRtpScriptTransformer}}:
 
 * keyframerequest of type {{KeyFrameRequestEvent}} - fired when the sink determines that a key frame has been requested.
 
 The steps that generate an event of type {{KeyFrameRequestEvent}} are as follows:
 
-Given a {{RTCRtpScriptTransformer}} `transform`:
+Given a {{RTCRtpScriptTransformer}} |transform|:
 
-When `transform`'s `[[encoder]]` receives a keyframe request, for instance from an incoming RTCP Picture Loss Indication (PLI)
-or Full Intra Refresh (FIR), queue
-a task to perform the following steps:
+When |transform|'s `[[encoder]]` receives a keyframe request, for instance from an incoming RTCP Picture Loss Indication (PLI)
+or Full Intra Refresh (FIR), queue a task to perform the following steps:
 
-1. Set `rid` to the RID of the appropriate layer, or undefined if the request is not for a specific layer.
-1. Fire a cancelable event of type {{KeyFrameRequestEvent}} on `transform`, with {{KeyFrameRequestEvent/rid}} set to `rid`.
-1. If the event is cancelled, abort these steps.
-1. Run the [$generate key frame algorithm$] with a new promise, `transform`.`[[encoder]]` and `rid`.
+1. Set |rid| to the RID of the appropriate layer, or undefined if the request is not for a specific layer.
+1. [=Fire an event=] named `keyframerequest` at |transform| using {{KeyFrameRequestEvent}} with its {{Event/cancelable}} attribute initialized to "true", and with {{KeyFrameRequestEvent/rid}} set to |rid|.
+1. If the event's `canceled flag` is true, abort these steps.
+1. Run the [$generate key frame algorithm$] with a new promise, |transform|.`[[encoder]]` and |rid|.
 
 ## KeyFrame Algorithms ## {#KeyFrame-algorithms}
 

--- a/index.bs
+++ b/index.bs
@@ -586,18 +586,34 @@ interface RTCTransformEvent : Event {
     readonly attribute RTCRtpScriptTransformer transformer;
 };
 
+interface BandwidthInfo {
+    readonly attribute long bandwidth;  // bits per second
+    readonly attribute long bufferDepth; // bytes that can be sent with no loss at sender
+};
+
 partial interface DedicatedWorkerGlobalScope {
     attribute EventHandler onrtctransform;
 };
 
-[Exposed=DedicatedWorker]
-interface RTCRtpScriptTransformer {
+interface mixin RTCRtpScriptSource {
     readonly attribute ReadableStream readable;
-    readonly attribute WritableStream writable;
-    readonly attribute any options;
     Promise&lt;unsigned long long&gt; generateKeyFrame(optional DOMString rid);
     Promise&lt;undefined&gt; sendKeyFrameRequest();
+    undefined bandwidthEstimate(BandwidthInfo info);
 };
+
+interface mixin RTCRtpScriptSink {
+    readonly attribute WritableStream writable;
+    attribute EventHandler onbandwidthestimate;
+    attribute EventHandler onkeyframerequest;
+};
+
+[Exposed=DedicatedWorker]
+interface RTCRtpScriptTransformer {
+    readonly attribute any options;
+};
+RTCRtpScriptTransformer includes RTCRtpScriptSource;
+RTCRtpScriptTransformer includes RTCRtpScriptSink;
 
 [Exposed=Window]
 interface RTCRtpScriptTransform {

--- a/index.bs
+++ b/index.bs
@@ -587,8 +587,9 @@ interface RTCTransformEvent : Event {
 };
 
 interface BandwidthInfo {
-    readonly attribute long bandwidth;  // bits per second
-    readonly attribute long bufferDepth; // bytes that can be sent with no loss at sender
+    readonly attribute long allocatedBitrate;  // bits per second
+    readonly attribute long availableOutgoingBitrate;
+    readonly attribute boolean writable;
 };
 
 partial interface DedicatedWorkerGlobalScope {
@@ -604,6 +605,7 @@ interface mixin RTCRtpScriptSource {
 
 interface mixin RTCRtpScriptSink {
     readonly attribute WritableStream writable;
+    attribute BandwidthInfo bandwidthInfo;
     attribute EventHandler onbandwidthestimate;
     attribute EventHandler onkeyframerequest;
 };
@@ -618,11 +620,6 @@ RTCRtpScriptTransformer includes RTCRtpScriptSink;
 [Exposed=Window]
 interface RTCRtpScriptTransform {
     constructor(Worker worker, optional any options, optional sequence&lt;object&gt; transfer);
-};
-
-interface BandwidthEstimateEvent : Event {
-  constructor(DOMString type, BandwidthInfo info);
-  readonly attribute BandwidthInfo bandwidthInfo;
 };
 
 interface KeyFrameRequestEvent : Event {
@@ -694,11 +691,22 @@ The <dfn attribute for="RTCRtpScriptSink">onbandwidthestimate</dfn> EventHandler
 
 The <dfn attribute for="RTCRtpScriptSink">onkeyframerequest</dfn> EventHandler has type keyframerequest.
 
-## Events ##
+## Attributes of BandwidthInfo ## {#BandwidthEstimate-attributes}
+The <dfn attribute for="BandwidthEstimate">allocatedBitrate</dfn> attribute represents the bandwith that the downstream
+entity recommends to be allocated for media from this source. If this number is exceeded, the downstream entity
+can drop frames to stay within the allocated bandwidth limit.
 
-The following events fire on an RTCRtpScriptTransform:
+The <dfn attribute for="BandwidthEstimate">availableOutgoingBitrate</dfn> attribute represents the overall bandwidth estimate
+of the downstream entity - for an {{RTCRtpSender}}, this is the same number as the {{RTCIceCandidatePairStats/availableOutgoingBitrate}} of the {{RTCIceCandidatePair}} object that is currently supporting the transport.
 
-* bandwidthestimate of type {{BandwidthEstimateEvent}} - fired when the sink determines that the bandwidth estimate has changed significantly from what has been previously signalled. In the context of {{RTCRtpScriptTransform}}, if the event is not cancelled, the information will be passed to the source as if the sendBandwidthEstimate() function had been called.
+The <dfn attribute for="BandwidthEstimate">writable</dfn> attribute is true whenever it is possible to enqueue a
+frame for processing without it being immediately discarded. Note that delivery is not guaranteed under any circumstance.
+
+## Events ## {#RTCRtpScriptTransformer-events}
+
+The following events fire on an {{RTCRtpScriptTransformer}}:
+
+* bandwidthestimate of type {{Event}} - fired when the sink determines that the bandwidth estimate has changed significantly from what has been previously signalled. Significant changes include a change to the "writable" attribute, a decrease of the "allocatedBitrate" attribute, or an increase of more than 10% of the "allocatedBitrate" attribute. In the context of {{RTCRtpScriptTransform}}, if the event is not cancelled, the information will be passed to the source as if the sendBandwidthEstimate() function had been called.
 
 * keyframerequest of type {{KeyFrameRequestEvent}} - fired when the sink determines that a key frame has been requested. In the context of {{RTCRtpScriptTransform}}, if the event is not cancelled, the information will be passed to the source as if the generateKeyFrame() function had been called. <!-- NOTE IN DRAFT: generateKeyFrame() and requestKeyFrame() should merge -->
 

--- a/index.bs
+++ b/index.bs
@@ -690,7 +690,7 @@ or Full Intra Refresh (FIR), queue a task to perform the following steps:
 
 1. Set |rid| to the RID of the appropriate layer, or undefined if the request is not for a specific layer.
 1. [=Fire an event=] named `keyframerequest` at |transform| using {{KeyFrameRequestEvent}} with its {{Event/cancelable}} attribute initialized to "true", and with {{KeyFrameRequestEvent/rid}} set to |rid|.
-1. If the event's `canceled flag` is true, abort these steps.
+1. If the event's [=Event/canceled flag=] is true, abort these steps.
 1. Run the [$generate key frame algorithm$] with a new promise, |transform|.`[[encoder]]` and |rid|.
 
 ## KeyFrame Algorithms ## {#KeyFrame-algorithms}

--- a/index.bs
+++ b/index.bs
@@ -619,6 +619,16 @@ RTCRtpScriptTransformer includes RTCRtpScriptSink;
 interface RTCRtpScriptTransform {
     constructor(Worker worker, optional any options, optional sequence&lt;object&gt; transfer);
 };
+
+interface BandwidthEstimateEvent : Event {
+  constructor(DOMString type, BandwidthInfo info);
+  readonly attribute BandwidthInfo bandwidthInfo;
+};
+
+interface KeyFrameRequestEvent : Event {
+  constructor(DOMString type, optional DOMString rid);
+  readonly attribute DOMString? rid;
+};
 </pre>
 
 ## Operations ## {#RTCRtpScriptTransform-operations}
@@ -652,15 +662,18 @@ Each RTCRtpScriptTransform has the following set of [$association steps$], given
     1. Set |transformer|.`[[encoder]]` to |encoder|.
     1. Set |transformer|.`[[depacketizer]]` to |depacketizer|.
 
-The <dfn method for="RTCRtpScriptTransformer">generateKeyFrame(|rid|)</dfn> method steps are:
+The <dfn method for="RTCRtpScriptSource">generateKeyFrame(|rid|)</dfn> method steps are:
 1. Let |promise| be a new promise.
 1. Run the [$generate key frame algorithm$] with |promise|, |this|.`[[encoder]]` and |rid|.
 1. Return |promise|.
 
-The <dfn method for="RTCRtpScriptTransformer">sendKeyFrameRequest()</dfn> method steps are:
+The <dfn method for="RTCRtpScriptSource">sendKeyFrameRequest()</dfn> method steps are:
 1. Let |promise| be a new promise.
 1. Run the [$send request key frame algorithm$] with |promise| and |this|.`[[depacketizer]]`.
 1. Return |promise|.
+
+The <dfn method for="RTCRtpScriptSource">bandwidthEstimate()</dfn> method step are:
+1. Configure the upstream source with the new bandwidth information.
 
 ## Attributes ## {#RTCRtpScriptTransformer-attributes}
 
@@ -671,11 +684,24 @@ This allows algorithms to go from an {{RTCRtpScriptTransformer}} object to its {
 The <dfn attribute for="RTCRtpScriptTransformer">options</dfn> getter steps are:
 1. Return [=this=].`[[options]]`.
 
-The <dfn attribute for="RTCRtpScriptTransformer">readable</dfn> getter steps are:
+The <dfn attribute for="RTCRtpScriptSource">readable</dfn> getter steps are:
 1. Return [=this=].`[[readable]]`.
 
-The <dfn attribute for="RTCRtpScriptTransformer">writable</dfn> getter steps are:
+The <dfn attribute for="RTCRtpScriptSink">writable</dfn> getter steps are:
 1. Return [=this=].`[[writable]]`.
+
+The <dfn attribute for="RTCRtpScriptSink">onbandwidthestimate</dfn> EventHandler has type bandwidthestimate.
+
+The <dfn attribute for="RTCRtpScriptSink">onkeyframerequest</dfn> EventHandler has type keyframerequest.
+
+## Events ##
+
+The following events fire on an RTCRtpScriptTransform:
+
+* bandwidthestimate of type {{BandwidthEstimateEvent}} - fired when the sink determines that the bandwidth estimate has changed significantly from what has been previously signalled. In the context of {{RTCRtpScriptTransform}}, if the event is not cancelled, the information will be passed to the source as if the bandwidthEstimate() function had been called.
+
+* keyframerequest of type {{KeyFrameRequestEvent}} - fired when the sink determines that a key frame has been requested. In the context of {{RTCRtpScriptTransform, if the event is not cancelled, the information will be passed to the source as if the generateKeyFrame() function had been called. <!-- NOTE IN DRAFT: generateKeyFrame() and requestKeyFrame() should merge -->
+
 
 ## KeyFrame Algorithms ## {#KeyFrame-algorithms}
 

--- a/index.bs
+++ b/index.bs
@@ -614,6 +614,7 @@ interface RTCRtpScriptTransform {
     constructor(Worker worker, optional any options, optional sequence&lt;object&gt; transfer);
 };
 
+[Exposed=DedicatedWorker]
 interface KeyFrameRequestEvent : Event {
   constructor(DOMString type, optional DOMString rid);
   readonly attribute DOMString? rid;

--- a/index.bs
+++ b/index.bs
@@ -586,12 +586,6 @@ interface RTCTransformEvent : Event {
     readonly attribute RTCRtpScriptTransformer transformer;
 };
 
-interface BandwidthInfo {
-    readonly attribute long allocatedBitrate;  // bits per second
-    readonly attribute long availableOutgoingBitrate;
-    readonly attribute boolean writable;
-};
-
 partial interface DedicatedWorkerGlobalScope {
     attribute EventHandler onrtctransform;
 };
@@ -600,13 +594,10 @@ interface mixin RTCRtpScriptSource {
     readonly attribute ReadableStream readable;
     Promise&lt;unsigned long long&gt; generateKeyFrame(optional DOMString rid);
     Promise&lt;undefined&gt; sendKeyFrameRequest();
-    undefined sendBandwidthEstimate(BandwidthInfo info);
 };
 
 interface mixin RTCRtpScriptSink {
     readonly attribute WritableStream writable;
-    attribute BandwidthInfo bandwidthInfo;
-    attribute EventHandler onbandwidthestimate;
     attribute EventHandler onkeyframerequest;
 };
 
@@ -614,6 +605,7 @@ interface mixin RTCRtpScriptSink {
 interface RTCRtpScriptTransformer {
     readonly attribute any options;
 };
+
 RTCRtpScriptTransformer includes RTCRtpScriptSource;
 RTCRtpScriptTransformer includes RTCRtpScriptSink;
 
@@ -669,9 +661,6 @@ The <dfn method for="RTCRtpScriptSource">sendKeyFrameRequest()</dfn> method step
 1. Run the [$send request key frame algorithm$] with |promise| and |this|.`[[depacketizer]]`.
 1. Return |promise|.
 
-The <dfn method for="RTCRtpScriptSource">sendBandwidthEstimate()</dfn> method step are:
-1. Configure the upstream source with the new bandwidth information.
-
 ## Attributes ## {#RTCRtpScriptTransformer-attributes}
 
 A {{RTCRtpScriptTransformer}} has the following private slots called `[[depacketizer]]`, `[[encoder]]`, `[[options]]`, `[[readable]]` and `[[writable]]`.
@@ -691,25 +680,11 @@ The <dfn attribute for="RTCRtpScriptSink">onbandwidthestimate</dfn> EventHandler
 
 The <dfn attribute for="RTCRtpScriptSink">onkeyframerequest</dfn> EventHandler has type keyframerequest.
 
-## Attributes of BandwidthInfo ## {#BandwidthEstimate-attributes}
-The <dfn attribute for="BandwidthEstimate">allocatedBitrate</dfn> attribute represents the bandwith that the downstream
-entity recommends to be allocated for media from this source. If this number is exceeded, the downstream entity
-can drop frames to stay within the allocated bandwidth limit.
-
-The <dfn attribute for="BandwidthEstimate">availableOutgoingBitrate</dfn> attribute represents the overall bandwidth estimate
-of the downstream entity - for an {{RTCRtpSender}}, this is the same number as the {{RTCIceCandidatePairStats/availableOutgoingBitrate}} of the {{RTCIceCandidatePair}} object that is currently supporting the transport.
-
-The <dfn attribute for="BandwidthEstimate">writable</dfn> attribute is true whenever it is possible to enqueue a
-frame for processing without it being immediately discarded. Note that delivery is not guaranteed under any circumstance.
-
 ## Events ## {#RTCRtpScriptTransformer-events}
 
 The following events fire on an {{RTCRtpScriptTransformer}}:
 
-* bandwidthestimate of type {{Event}} - fired when the sink determines that the bandwidth estimate has changed significantly from what has been previously signalled. Significant changes include a change to the "writable" attribute, a decrease of the "allocatedBitrate" attribute, or an increase of more than 10% of the "allocatedBitrate" attribute. In the context of {{RTCRtpScriptTransform}}, if the event is not cancelled, the information will be passed to the source as if the sendBandwidthEstimate() function had been called.
-
 * keyframerequest of type {{KeyFrameRequestEvent}} - fired when the sink determines that a key frame has been requested. In the context of {{RTCRtpScriptTransform}}, if the event is not cancelled, the information will be passed to the source as if the generateKeyFrame() function had been called. <!-- NOTE IN DRAFT: generateKeyFrame() and requestKeyFrame() should merge -->
-
 
 ## KeyFrame Algorithms ## {#KeyFrame-algorithms}
 

--- a/index.bs
+++ b/index.bs
@@ -591,23 +591,23 @@ partial interface DedicatedWorkerGlobalScope {
 };
 
 interface mixin RTCRtpScriptSource {
-    readonly attribute ReadableStream readable;
-    Promise&lt;unsigned long long&gt; generateKeyFrame(optional DOMString rid);
-    Promise&lt;undefined&gt; sendKeyFrameRequest();
 };
 
 interface mixin RTCRtpScriptSink {
-    readonly attribute WritableStream writable;
-    attribute EventHandler onkeyframerequest;
 };
 
 [Exposed=DedicatedWorker]
 interface RTCRtpScriptTransformer {
+    // Attributes and methods related to the transformer source
+    readonly attribute ReadableStream readable;
+    Promise&lt;unsigned long long&gt; generateKeyFrame(optional DOMString rid);
+    Promise&lt;undefined&gt; sendKeyFrameRequest();
+    // Attributes and methods related to the transformer sink
+    readonly attribute WritableStream writable;
+    attribute EventHandler onkeyframerequest;
+    // Attributes for configuring the Javascript code
     readonly attribute any options;
 };
-
-RTCRtpScriptTransformer includes RTCRtpScriptSource;
-RTCRtpScriptTransformer includes RTCRtpScriptSink;
 
 [Exposed=Window]
 interface RTCRtpScriptTransform {
@@ -652,12 +652,12 @@ Each RTCRtpScriptTransform has the following set of [$association steps$], given
     1. Set |transformer|.`[[encoder]]` to |encoder|.
     1. Set |transformer|.`[[depacketizer]]` to |depacketizer|.
 
-The <dfn method for="RTCRtpScriptSource">generateKeyFrame(|rid|)</dfn> method steps are:
+The <dfn method for="RTCRtpScriptTransform">generateKeyFrame(|rid|)</dfn> method steps are:
 1. Let |promise| be a new promise.
 1. Run the [$generate key frame algorithm$] with |promise|, |this|.`[[encoder]]` and |rid|.
 1. Return |promise|.
 
-The <dfn method for="RTCRtpScriptSource">sendKeyFrameRequest()</dfn> method steps are:
+The <dfn method for="RTCRtpScriptTransform">sendKeyFrameRequest()</dfn> method steps are:
 1. Let |promise| be a new promise.
 1. Run the [$send request key frame algorithm$] with |promise| and |this|.`[[depacketizer]]`.
 1. Return |promise|.
@@ -671,21 +671,34 @@ This allows algorithms to go from an {{RTCRtpScriptTransformer}} object to its {
 The <dfn attribute for="RTCRtpScriptTransformer">options</dfn> getter steps are:
 1. Return [=this=].`[[options]]`.
 
-The <dfn attribute for="RTCRtpScriptSource">readable</dfn> getter steps are:
+The <dfn attribute for="RTCRtpScriptTransform">readable</dfn> getter steps are:
 1. Return [=this=].`[[readable]]`.
 
-The <dfn attribute for="RTCRtpScriptSink">writable</dfn> getter steps are:
+The <dfn attribute for="RTCRtpScriptTransform">writable</dfn> getter steps are:
 1. Return [=this=].`[[writable]]`.
 
-The <dfn attribute for="RTCRtpScriptSink">onbandwidthestimate</dfn> EventHandler has type bandwidthestimate.
+The <dfn attribute for="RTCRtpScriptTransform">onbandwidthestimate</dfn> EventHandler has type bandwidthestimate.
 
-The <dfn attribute for="RTCRtpScriptSink">onkeyframerequest</dfn> EventHandler has type keyframerequest.
+The <dfn attribute for="RTCRtpScriptTransform">onkeyframerequest</dfn> EventHandler has type keyframerequest.
 
 ## Events ## {#RTCRtpScriptTransformer-events}
 
 The following events fire on an {{RTCRtpScriptTransformer}}:
 
-* keyframerequest of type {{KeyFrameRequestEvent}} - fired when the sink determines that a key frame has been requested. In the context of {{RTCRtpScriptTransform}}, if the event is not cancelled, the information will be passed to the source as if the generateKeyFrame() function had been called. <!-- NOTE IN DRAFT: generateKeyFrame() and requestKeyFrame() should merge -->
+* keyframerequest of type {{KeyFrameRequestEvent}} - fired when the sink determines that a key frame has been requested.
+
+The steps that generate an event of type {{KeyFrameRequestEvent}} are as follows:
+
+Given a {{RTCRtpScriptTransformer}} `transform`:
+
+When `transform`'s `[[encoder]]` receives a keyframe request, for instance from an incoming RTCP Picture Loss Indication (PLI)
+or Full Intra Refresh (FIR), queue
+a task to perform the following steps:
+
+1. Set `rid` to the RID of the appropriate layer, or undefined if the request is not for a specific layer.
+1. Fire a cancelable event of type {{KeyFrameRequestEvent}} on `transform`, with {{KeyFrameRequestEvent/rid}} set to `rid`.
+1. If the event is cancelled, abort these steps.
+1. Run the [$generate key frame algorithm$] with a new promise, `transform`.`[[encoder]]` and `rid`.
 
 ## KeyFrame Algorithms ## {#KeyFrame-algorithms}
 


### PR DESCRIPTION
This is split from #207  - in the October interim discussion, the overall congestion control API was seen as requiring more discussion, but the keyframe proposal was thought reasonable to pursue on its own.

I preserved the split into "ScriptSource" and "ScriptSink" interfaces - I think that can be valuable for documenting which interfaces are facing in which direction on the transformer.

Comments welcome.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/pull/215.html" title="Last updated on Dec 12, 2023, 10:19 AM UTC (0079fa4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/215/09f618e...0079fa4.html" title="Last updated on Dec 12, 2023, 10:19 AM UTC (0079fa4)">Diff</a>