### PR TITLE
Readable and Writable [[owner]] slots are unused

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -84,15 +84,13 @@ argument, ensure that the codec is disabled and produces no output.
 ### Stream creation ### {#stream-creation}
 
 At construction of each {{RTCRtpSender}} or {{RTCRtpReceiver}}, run the following steps:
-2. Initialize [=this=].`[[transform]]` to null.
-3. Initialize [=this=].`[[readable]]` to a new {{ReadableStream}}.
-4. <a dfn for="ReadableStream">Set up</a> [=this=].`[[readable]]`. [=this=].`[[readable]]` is provided frames using the [$readEncodedData$] algorithm given |this| as parameter.
-5. Set [=this=].`[[readable]]`.`[[owner]]` to |this|.
-6. Initialize [=this=].`[[writable]]` to a new {{WritableStream}}.
-7. <a dfn for="WritableStream">Set up</a> [=this=].`[[writable]]` with its [=WritableStream/set up/writeAlgorithm=] set to [$writeEncodedData$] given |this| as parameter and its [=WritableStream/set up/highWaterMark=] set to <code>Infinity</code>.
+1. Initialize [=this=].`[[transform]]` to null.
+1. Initialize [=this=].`[[readable]]` to a new {{ReadableStream}}.
+1. <a dfn for="ReadableStream">Set up</a> [=this=].`[[readable]]`. [=this=].`[[readable]]` is provided frames using the [$readEncodedData$] algorithm given |this| as parameter.
+1. Initialize [=this=].`[[writable]]` to a new {{WritableStream}}.
+1. <a dfn for="WritableStream">Set up</a> [=this=].`[[writable]]` with its [=WritableStream/set up/writeAlgorithm=] set to [$writeEncodedData$] given |this| as parameter and its [=WritableStream/set up/highWaterMark=] set to <code>Infinity</code>.
     <p class="note">highWaterMark is set to Infinity to explicitly disable backpressure.</p>
-8. Set [=this=].`[[writable]]`.`[[owner]]` to |this|.
-9. Initialize [=this=].`[[pipeToController]]` to null.
+1. Initialize [=this=].`[[pipeToController]]` to null.
 1. Initialize [=this=].`[[lastReceivedFrameCounter]]` to <code>0</code>.
 1. Initialize [=this=].`[[lastEnqueuedFrameCounter]]` to <code>0</code>.
 1. [=Queue a task=] to run the following steps:


### PR DESCRIPTION
Let's remove them.

Fixes https://github.com/w3c/webrtc-encoded-transform/issues/217


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-insertable-streams/pull/219.html" title="Last updated on Dec 7, 2023, 9:56 AM UTC (4cddec4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/219/32f00c2...youennf:4cddec4.html" title="Last updated on Dec 7, 2023, 9:56 AM UTC (4cddec4)">Diff</a>