### PR TITLE
Add definition of RTCEncodedVideoFrameMetadata frameId and dependencies

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -347,6 +347,25 @@ dictionary RTCEncodedVideoFrameMetadata {
 
 <dl dfn-for="RTCEncodedVideoFrameMetadata" class="dictionary-members">
     <dt>
+        <dfn dict-member>frameId</dfn> <span class="idlMemberType">unsigned long long</span>
+    </dt>
+    <dd>
+        <p>
+            An identifier for the encoded frame, monotonically increasing in decode order. Its lower
+            16 bits matches the frame_number of the Dependency Descriptor RTP Header Extension, if sent.
+            Only present for received frames if the Dependency Descriptor Header Extension is present.
+        </p>
+    </dd>
+    <dt>
+        <dfn dict-member>dependencies</dfn> <span class="idlMemberType">sequence&lt;unsigned long long&gt;</span>
+    </dt>
+    <dd>
+        <p>
+            List of frameIds of frames this frame references.
+            Only present for received frames if the Dependency Descriptor Header Extension is present.
+        </p>
+    </dd>
+    <dt>
         <dfn dict-member>synchronizationSource</dfn> <span class="idlMemberType">unsigned long</span>
     </dt>
     <dd>

--- a/index.bs
+++ b/index.bs
@@ -352,7 +352,7 @@ dictionary RTCEncodedVideoFrameMetadata {
     <dd>
         <p>
             An identifier for the encoded frame, monotonically increasing in decode order. Its lower
-            16 bits match the frame_number of the AV1 Dependency Descriptor Header Extension defined in Appendix A of [[?AV1-RTP]], if sent.
+            16 bits match the frame_number of the AV1 Dependency Descriptor Header Extension defined in Appendix A of [[?AV1-RTP]], if present.
             Only present for received frames if the Dependency Descriptor Header Extension is present.
         </p>
     </dd>

--- a/index.bs
+++ b/index.bs
@@ -352,7 +352,7 @@ dictionary RTCEncodedVideoFrameMetadata {
     <dd>
         <p>
             An identifier for the encoded frame, monotonically increasing in decode order. Its lower
-            16 bits matches the frame_number of the Dependency Descriptor RTP Header Extension, if sent.
+            16 bits match the frame_number of the AV1 Dependency Descriptor Header Extension defined in Appendix A of [[?AV1-RTP]], if sent.
             Only present for received frames if the Dependency Descriptor Header Extension is present.
         </p>
     </dd>
@@ -362,7 +362,7 @@ dictionary RTCEncodedVideoFrameMetadata {
     <dd>
         <p>
             List of frameIds of frames this frame references.
-            Only present for received frames if the Dependency Descriptor Header Extension is present.
+            Only present for received frames if the AV1 Dependency Descriptor Header Extension defined in Appendix A of [[?AV1-RTP]] is present.
         </p>
     </dd>
     <dt>

--- a/index.bs
+++ b/index.bs
@@ -352,7 +352,7 @@ dictionary RTCEncodedVideoFrameMetadata {
     <dd>
         <p>
             An identifier for the encoded frame, monotonically increasing in decode order. Its lower
-            16 bits match the frame_number of the AV1 Dependency Descriptor Header Extension defined in Appendix A of [[?AV1-RTP]], if present.
+            16 bits match the frame_number of the AV1 Dependency Descriptor Header Extension defined in Appendix A of [[?AV1-RTP-SPEC]], if present.
             Only present for received frames if the Dependency Descriptor Header Extension is present.
         </p>
     </dd>

--- a/index.bs
+++ b/index.bs
@@ -362,7 +362,7 @@ dictionary RTCEncodedVideoFrameMetadata {
     <dd>
         <p>
             List of frameIds of frames this frame references.
-            Only present for received frames if the AV1 Dependency Descriptor Header Extension defined in Appendix A of [[?AV1-RTP]] is present.
+            Only present for received frames if the AV1 Dependency Descriptor Header Extension defined in Appendix A of [[?AV1-RTP-SPEC]] is present.
         </p>
     </dd>
     <dt>


### PR DESCRIPTION
Fixes Issue #220


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tonyherre/webrtc-encoded-transform/pull/222.html" title="Last updated on Jan 23, 2024, 10:04 PM UTC (9691a88)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/222/09f618e...tonyherre:9691a88.html" title="Last updated on Jan 23, 2024, 10:04 PM UTC (9691a88)">Diff</a>