### PR TITLE
Fix grammar typo

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -509,7 +509,7 @@ interface RTCEncodedVideoFrame {
         </p>
         <p class="note">
               Since packetizers may drop certain elements, e.g. AV1 temporal delimiter OBUs,
-              the input to an receive-side transform may be different from the output of
+              the input to a receive-side transform may be different from the output of
               a send-side transform.
         </p>
         <p>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/pull/241.html" title="Last updated on Feb 24, 2025, 2:33 PM UTC (be80e41)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/241/8f8110e...be80e41.html" title="Last updated on Feb 24, 2025, 2:33 PM UTC (be80e41)">Diff</a>