### PR TITLE
Clarify that synchronous rejection happens for audio receivers

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1070,7 +1070,7 @@ If the promise is associated to several rid values, it will be resolved when the
 
 The <dfn abstract-op>send request key frame algorithm</dfn>, given |promise| and |depacketizer|, is defined by running these steps:
 1. If |depacketizer| is undefined, reject |promise| with {{InvalidStateError}}, abort these steps.
-1. If |depacketizer| belongs to an audio {{RTCRtpReceiver}}, reject |promise| with {{InvalidStateError}}, abort these steps.
+1. If |depacketizer| does not belong to a video {{RTCRtpReceiver}}, reject |promise| with {{InvalidStateError}}, abort these steps.
 1. [=In parallel=], run the following steps:
     1. If sending a Full Intra Request (FIR) by |depacketizer|'s receiver is not deemed appropriate, [=resolve=] |promise| with undefined and abort these steps.
         Section 4.3.1 of [[RFC5104]] provides guidelines of how and when it is appropriate to sending a Full Intra Request.

--- a/index.bs
+++ b/index.bs
@@ -1070,7 +1070,7 @@ If the promise is associated to several rid values, it will be resolved when the
 
 The <dfn abstract-op>send request key frame algorithm</dfn>, given |promise| and |depacketizer|, is defined by running these steps:
 1. If |depacketizer| is undefined, reject |promise| with {{InvalidStateError}}, abort these steps.
-1. If |depacketizer| is not processing video packets, reject |promise| with {{InvalidStateError}}, abort these steps.
+1. If |depacketizer| belongs to an audio {{RTCRtpReceiver}}, reject |promise| with {{InvalidStateError}}, abort these steps.
 1. [=In parallel=], run the following steps:
     1. If sending a Full Intra Request (FIR) by |depacketizer|'s receiver is not deemed appropriate, [=resolve=] |promise| with undefined and abort these steps.
         Section 4.3.1 of [[RFC5104]] provides guidelines of how and when it is appropriate to sending a Full Intra Request.


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-encoded-transform/issues/230


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-insertable-streams/pull/247.html" title="Last updated on Apr 24, 2025, 2:02 PM UTC (ae9fdcb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/247/c45d125...youennf:ae9fdcb.html" title="Last updated on Apr 24, 2025, 2:02 PM UTC (ae9fdcb)">Diff</a>