### PR TITLE
Explicitly throw InvalidStateError when trying to reuse a transform

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -177,7 +177,10 @@ As [$writeEncodedData$] ensures that the transform cannot reorder frames, this w
 
 ## Extension attribute ## {#attribute}
 
-A RTCRtpTransform has two private slots called `[[readable]]` and `[[writable]]`.
+A RTCRtpTransform has private slots:
+* `[[readable]]` of type {{ReadableStream}}.
+* `[[writable]]` of type {{WritableStream}}.
+* `[[owner]]` of type {{RTCRtpSender}} or {{RTCRtpReceiver}}, initialized to null.
 
 Each RTCRtpTransform has an <dfn abstract-op for=RTCRtpTransform>association steps</dfn> set, which is empty by default.
 
@@ -185,18 +188,20 @@ The <dfn attribute for="RTCRtpSender,RTCRtpReceiver">transform</dfn> getter step
 1. Return [=this=].`[[transform]]`.
 
 The `transform` setter steps are:
-2. Let |transform| be the argument to the setter.
-3. Let |checkedTransform| set to |transform| if it is not null or to an [=identity transform stream=] otherwise.
-3. Let |reader| be the result of [=ReadableStream/getting a reader=] for |checkedTransform|.`[[readable]]`.
-4. Let |writer| be the result of [=WritableStream/getting a writer=] for |checkedTransform|.`[[writable]]`.
-5. Initialize |newPipeToController| to a new {{AbortController}}.
-6. If [=this=].`[[pipeToController]]` is not null, run the following steps:
+1. Let |transform| be the argument to the setter.
+1. Let |checkedTransform| set to |transform| if it is not null or to an [=identity transform stream=] otherwise.
+1. If |checkedTransform|.`[[owner]]` is not null, throw a {{InvalidStateError}} and abort these steps.
+1. Let |reader| be the result of [=ReadableStream/getting a reader=] for |checkedTransform|.`[[readable]]`.
+1. Let |writer| be the result of [=WritableStream/getting a writer=] for |checkedTransform|.`[[writable]]`.
+1. Set |checkedTransform|.`[[owner]]` to [=this=].
+1. Initialize |newPipeToController| to a new {{AbortController}}.
+1. If [=this=].`[[pipeToController]]` is not null, run the following steps:
     1. [=AbortSignal/Add=] the [$chain transform algorithm$] to [=this=].`[[pipeToController]]`'s [=AbortController/signal=].
     2. [=AbortController/signal abort=] on [=this=].`[[pipeToController]]`.
-7. Else, run the [$chain transform algorithm$] steps.
-8. Set [=this=].`[[pipeToController]]` to |newPipeToController|.
-9. Set [=this=].`[[transform]]` to |transform|.
-10. Run the steps in the set of [$association steps$] of |transform| with [=this=].
+1. Else, run the [$chain transform algorithm$] steps.
+1. Set [=this=].`[[pipeToController]]` to |newPipeToController|.
+1. Set [=this=].`[[transform]]` to |transform|.
+1. Run the steps in the set of [$association steps$] of |transform| with [=this=].
 
 The <dfn abstract-op>chain transform algorithm</dfn> steps are defined as:
 1. If |newPipeToController|'s [=AbortController/signal=] is [=AbortSignal/aborted=], abort these steps.


### PR DESCRIPTION
This aligns with the type used by implementations.
Before the PR, spec would mandate to throw `TypeError` as part of acquiring reader/writer.