### PR TITLE
Clarify that generateKeyFrame() rejects immediately for audio receivers

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -998,7 +998,7 @@ or Full Intra Refresh (FIR), queue a task to perform the following steps:
 
 The <dfn abstract-op>generate key frame algorithm</dfn>, given |promise|, |encoder| and |rid|, is defined by running these steps:
 1. If |encoder| is undefined, reject |promise| with {{InvalidStateError}}, abort these steps.
-1. If |encoder| is not processing video frames, reject |promise| with {{InvalidStateError}}, abort these steps.
+1. If |encoder| does not belong to a video {{RTCRtpReceiver}}, reject |promise| with {{InvalidStateError}}, abort these steps.
 1. If |rid| is defined, but does not conform to the grammar requirements specified
     in Section 10 of [[!RFC8851]], then reject |promise| with {{TypeError}} and abort
     these steps.


### PR DESCRIPTION
Fixes #267


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webrtc-encoded-transform/pull/277.html" title="Last updated on Aug 13, 2025, 6:43 PM UTC (c982880)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/277/9cf200f...jan-ivar:c982880.html" title="Last updated on Aug 13, 2025, 6:43 PM UTC (c982880)">Diff</a>