### PR TITLE
Align RTCEncodedVideoFrame type handling to how data is handled.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -585,6 +585,7 @@ interface RTCEncodedVideoFrame {
             {{RTCEncodedFrameMetadata/mimeType}}.
             For <a href="https://w3c.github.io/webrtc-svc/">SVC</a>, each spatial layer
             is transformed separately.
+            On getting, |this|.`[[data]]` MUST be returned. On setting, |this|.`[[data]]` MUST be set to the new value.
         </p>
         <p class="note">
               Since packetizers may drop certain elements, e.g. AV1 temporal delimiter OBUs,
@@ -667,14 +668,14 @@ interface RTCEncodedVideoFrame {
 Their [=serialization steps=], given |value|, |serialized|, and |forStorage|, are:
 
 1. If |forStorage| is true, then throw a {{DataCloneError}}.
-1. Set |serialized|.`[[type]]` to the value of |value|.{{RTCEncodedVideoFrame/type}}.
+1. Set |serialized|.`[[type]]` to the value of |value|.`[[type]]`.
 1. Set |serialized|.`[[metadata]]` to an internal representation of |value|'s metadata.
 1. Set |serialized|.`[[data]]` to the [=sub-serialization=] of |value|.`[[data]]`.
 
 
 Their [=deserialization steps=], given |serialized|, |value| and |realm|, are:
 
-1. Set |value|.{{RTCEncodedVideoFrame/type}} to |serialized|.`[[type]]`.
+1. Set |value|.`[[type]]` to |serialized|.`[[type]]`.
 1. Set |value|'s metadata to the platform object representation of |serialized|.`[[metadata]]`.
 1. Set |value|.`[[data]]` to the [=sub-deserialization=] of |serialized|.`[[data]]`.
 
@@ -783,6 +784,7 @@ interface RTCEncodedAudioFrame {
             The encoded frame data. The format of the data depends on the audio codec that is
             used to encode/decode the frame which can be determined by looking at the
             {{RTCEncodedFrameMetadata/mimeType}}.
+            On getting, |this|.`[[data]]` MUST be returned. On setting, |this|.`[[data]]` MUST be set to the new value.
             The following table gives a number of examples:
         </p>
         <table class="simple">

--- a/index.bs
+++ b/index.bs
@@ -571,8 +571,8 @@ interface RTCEncodedVideoFrame {
     </dt>
     <dd>
         <p>
-            The type attribute allows the application to determine when a key frame is being
-            sent or received.
+            The type attribute allows the application to determine when a frame is a key frame or a delta frame.
+            On getting, |this|.`[[type]]` MUST be returned.
         </p>
     </dd>
     <dt>


### PR DESCRIPTION
We use a [[type]] slot and set it in constructor, as well as deserialization steps. We make it clear that data/type attributes are related to [[type]]/[[data]] slots.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-insertable-streams/pull/279.html" title="Last updated on Aug 21, 2025, 2:56 PM UTC (e56b05b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/279/9cf200f...youennf:e56b05b.html" title="Last updated on Aug 21, 2025, 2:56 PM UTC (e56b05b)">Diff</a>