### PR TITLE
Revert the renaming of SFrameTransformOptions to RTCSFrameTransformOptions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -220,7 +220,7 @@ enum SFrameCipherSuite {
      "AES_256_GCM_SHA512_128"
 };
 
-dictionary RTCSFrameTransformOptions {
+dictionary SFrameTransformOptions {
     required SFrameCipherSuite cipherSuite;
 };
 
@@ -239,13 +239,13 @@ interface mixin SFrameDecrypterManager {
 
 [Exposed=Window]
 interface RTCSFrameSenderTransform {
-    constructor(optional RTCSFrameTransformOptions options = {});
+    constructor(optional SFrameTransformOptions options = {});
 };
 RTCSFrameSenderTransform includes SFrameEncrypterManager;
 
 [Exposed=Window]
 interface RTCSFrameReceiverTransform : EventTarget {
-    constructor(optional RTCSFrameTransformOptions options = {});
+    constructor(optional SFrameTransformOptions options = {});
 };
 RTCSFrameReceiverTransform includes SFrameDecrypterManager;
 


### PR DESCRIPTION
Revert the renaming of SFrameTransformOptions to RTCSFrameTransformOptions
This is a partial revert of https://github.com/w3c/webrtc-encoded-transform/pull/291.
Fixes https://github.com/w3c/webrtc-encoded-transform/issues/296


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-insertable-streams/pull/297.html" title="Last updated on Feb 9, 2026, 2:38 PM UTC (94b4f98)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/297/5f22d21...youennf:94b4f98.html" title="Last updated on Feb 9, 2026, 2:38 PM UTC (94b4f98)">Diff</a>