### PR TITLE
Update Makefile to use spec-generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 index.html: index.bs
-	curl https://api.csswg.org/bikeshed/ -F file=@index.bs  > index.html
+	curl https://www.w3.org/publications/spec-generator/ -F file=@index.bs -F type=bikeshed-spec > index.html
 
 check: index.bs
-	curl https://api.csswg.org/bikeshed/ -F file=@index.bs -F output=err
+	curl https://www.w3.org/publications/spec-generator/ -F file=@index.bs -F type=bikeshed-spec -F output=messages


### PR DESCRIPTION
This updates the Makefile, which referenced the discontinued api.csswg.org/bikeshed HTTP API, to instead use https://www.w3.org/publications/spec-generator/.

I compared output against the current ED to ensure it mostly matches, but note that bikeshed currently encounters 2 link errors in this spec.