### PR TITLE
Adding the 3 cipher suites defined in https://www.ietf.org/archive/id/draft-barnes-sframe-iana-256-03.html

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -240,13 +240,16 @@ The APIs presented in this section allow applications to process SFrame data usi
 </p>
 
 <xmp class="idl">
-// List of supported cipher suites, as defined in [[RFC9605]] section 4.5.
+// List of supported cipher suites, as defined in [[RFC9605]] section 4.5 and in https://datatracker.ietf.org/doc/draft-barnes-sframe-iana-256/.
 enum SFrameCipherSuite {
      "AES_128_CTR_HMAC_SHA256_80",
      "AES_128_CTR_HMAC_SHA256_64",
      "AES_128_CTR_HMAC_SHA256_32",
      "AES_128_GCM_SHA256_128",
-     "AES_256_GCM_SHA512_128"
+     "AES_256_GCM_SHA512_128",
+     "AES_256_CTR_HMAC_SHA512_80",
+     "AES_256_CTR_HMAC_SHA512_64",
+     "AES_256_CTR_HMAC_SHA512_32"
 };
 
 dictionary SFrameTransformOptions {


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-encoded-transform/issues/302


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-insertable-streams/pull/303.html" title="Last updated on Apr 14, 2026, 7:46 AM UTC (963562e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/303/97bb86e...youennf:963562e.html" title="Last updated on Apr 14, 2026, 7:46 AM UTC (963562e)">Diff</a>