### PR TITLE
SFrame constructors cannot take an optional options parameter

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -277,26 +277,26 @@ interface mixin SFrameDecrypterManager {
 
 [Exposed=Window]
 interface RTCSFrameSenderTransform {
-    constructor(optional RTCSFrameSenderTransformOptions options = {});
+    constructor(RTCSFrameSenderTransformOptions options);
 };
 RTCSFrameSenderTransform includes SFrameEncrypterManager;
 
 [Exposed=Window]
 interface RTCSFrameReceiverTransform : EventTarget {
-    constructor(optional SFrameTransformOptions options = {});
+    constructor(SFrameTransformOptions options);
 };
 RTCSFrameReceiverTransform includes SFrameDecrypterManager;
 
 [Exposed=(Window,DedicatedWorker)]
 interface SFrameEncrypterStream : EventTarget {
-    constructor(optional SFrameTransformOptions options = {});
+    constructor(SFrameTransformOptions options);
 };
 SFrameEncrypterStream includes GenericTransformStream;
 SFrameEncrypterStream includes SFrameEncrypterManager;
 
 [Exposed=(Window,DedicatedWorker)]
 interface SFrameDecrypterStream : EventTarget {
-    constructor(optional SFrameTransformOptions options = {});
+    constructor(SFrameTransformOptions options);
 };
 SFrameDecrypterStream includes GenericTransformStream;
 SFrameDecrypterStream includes SFrameDecrypterManager;


### PR DESCRIPTION
Fixes https://github.com/w3c/webrtc-encoded-transform/issues/283


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-insertable-streams/pull/304.html" title="Last updated on Apr 14, 2026, 7:37 AM UTC (e751a03)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/304/97bb86e...youennf:e751a03.html" title="Last updated on Apr 14, 2026, 7:37 AM UTC (e751a03)">Diff</a>