### PR TITLE
SFrameEncrypterStream  does not need to be an EventTarget

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -291,7 +291,7 @@ interface RTCSFrameReceiverTransform : EventTarget {
 RTCSFrameReceiverTransform includes SFrameDecrypterManager;
 
 [Exposed=(Window,DedicatedWorker)]
-interface SFrameEncrypterStream : EventTarget {
+interface SFrameEncrypterStream {
     constructor(SFrameTransformOptions options);
 };
 SFrameEncrypterStream includes GenericTransformStream;


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webrtc-insertable-streams/pull/309.html" title="Last updated on May 13, 2026, 2:22 PM UTC (ce45265)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/309/f31b461...youennf:ce45265.html" title="Last updated on May 13, 2026, 2:22 PM UTC (ce45265)">Diff</a>