### PR TITLE
Update SFrameTransformErrorEvent frame type from any to RTCEncodedVideoFrame or RTCEncodedAudioFrame

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -316,12 +316,12 @@ interface SFrameTransformErrorEvent : Event {
 
     readonly attribute SFrameTransformErrorEventType errorType;
     readonly attribute CryptoKeyID? keyID;
-    readonly attribute any frame;
+    readonly attribute (RTCEncodedVideoFrame or RTCEncodedAudioFrame) frame;
 };
 
 dictionary SFrameTransformErrorEventInit : EventInit {
     required SFrameTransformErrorEventType errorType;
-    required any frame;
+    required (RTCEncodedVideoFrame or RTCEncodedAudioFrame) frame;
     CryptoKeyID? keyID;
 };
 </xmp>


### PR DESCRIPTION
# Summary

Updates the frame member type on SFrameTransformErrorEvent and SFrameTransformErrorEventInit from any to the more specific union (RTCEncodedVideoFrame or RTCEncodedAudioFrame).

# Motivation

The frame attribute previously used any, which provided no type information to web developers about what kind of object is exposed when an SFrame transform error occurs. Since the frame in question is always an encoded media frame, typing it as (RTCEncodedVideoFrame or RTCEncodedAudioFrame) better reflects the actual value and improves the precision of the IDL.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/k-wasniowski/webrtc-encoded-transform/pull/313.html" title="Last updated on Jun 23, 2026, 1:29 PM UTC (800842c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-encoded-transform/313/3495456...k-wasniowski:800842c.html" title="Last updated on Jun 23, 2026, 1:29 PM UTC (800842c)">Diff</a>